### PR TITLE
make Marklight processing pluggable

### DIFF
--- a/Marklight.xcodeproj/project.pbxproj
+++ b/Marklight.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		503683F41F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */; };
 		503683F61F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F51F2095E3006A7344 /* MarklightTextProcessingResult.swift */; };
 		503683F71F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F51F2095E3006A7344 /* MarklightTextProcessingResult.swift */; };
+		503683F91F209665006A7344 /* MarklightTextProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F81F209665006A7344 /* MarklightTextProcessorTests.swift */; };
+		503683FA1F209689006A7344 /* MarklightTextProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F81F209665006A7344 /* MarklightTextProcessorTests.swift */; };
+		503683FC1F209F33006A7344 /* MarklightStyleApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683FB1F209F33006A7344 /* MarklightStyleApplier.swift */; };
+		503683FD1F209F33006A7344 /* MarklightStyleApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683FB1F209F33006A7344 /* MarklightStyleApplier.swift */; };
 		95C46D6C1C33E11A0070AEDC /* Marklight.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C46D6B1C33E11A0070AEDC /* Marklight.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		95C46D731C33E11A0070AEDC /* Marklight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C46D681C33E11A0070AEDC /* Marklight.framework */; };
 		95C46D781C33E11A0070AEDC /* MarklightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D771C33E11A0070AEDC /* MarklightTests.swift */; };
@@ -53,6 +57,8 @@
 		503683EF1F208690006A7344 /* UniversalTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalTypes.swift; sourceTree = "<group>"; };
 		503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+paragraphRangeAt.swift"; sourceTree = "<group>"; };
 		503683F51F2095E3006A7344 /* MarklightTextProcessingResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessingResult.swift; sourceTree = "<group>"; };
+		503683F81F209665006A7344 /* MarklightTextProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessorTests.swift; sourceTree = "<group>"; };
+		503683FB1F209F33006A7344 /* MarklightStyleApplier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightStyleApplier.swift; sourceTree = "<group>"; };
 		95C46D681C33E11A0070AEDC /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Marklight.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		95C46D6B1C33E11A0070AEDC /* Marklight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Marklight.h; sourceTree = "<group>"; };
 		95C46D6D1C33E11A0070AEDC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -145,6 +151,7 @@
 			isa = PBXGroup;
 			children = (
 				95C46D821C33E1300070AEDC /* Marklight.swift */,
+				503683FB1F209F33006A7344 /* MarklightStyleApplier.swift */,
 				503683EF1F208690006A7344 /* UniversalTypes.swift */,
 				95C46D831C33E1300070AEDC /* MarklightTextStorage.swift */,
 				503683EC1F207DCD006A7344 /* MarklightTextProcessor.swift */,
@@ -161,6 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				95C46D771C33E11A0070AEDC /* MarklightTests.swift */,
+				503683F81F209665006A7344 /* MarklightTextProcessorTests.swift */,
 				95C46D791C33E11A0070AEDC /* Info.plist */,
 			);
 			path = MarklightTests;
@@ -346,6 +354,7 @@
 			files = (
 				503683F41F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */,
 				503683EE1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */,
+				503683FD1F209F33006A7344 /* MarklightStyleApplier.swift in Sources */,
 				503683F11F208690006A7344 /* UniversalTypes.swift in Sources */,
 				500DC5571F1F508500FE8C3E /* MarklightTextStorage.swift in Sources */,
 				503683F71F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */,
@@ -357,6 +366,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				503683FA1F209689006A7344 /* MarklightTextProcessorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -371,6 +381,7 @@
 				503683ED1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */,
 				503683F01F208690006A7344 /* UniversalTypes.swift in Sources */,
 				503683F61F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */,
+				503683FC1F209F33006A7344 /* MarklightStyleApplier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -379,6 +390,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				95C46D781C33E11A0070AEDC /* MarklightTests.swift in Sources */,
+				503683F91F209665006A7344 /* MarklightTextProcessorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Marklight.xcodeproj/project.pbxproj
+++ b/Marklight.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		500DC5561F1F4BDC00FE8C3E /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500DC5551F1F4BDC00FE8C3E /* Array+appending.swift */; };
 		500DC5571F1F508500FE8C3E /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D831C33E1300070AEDC /* MarklightTextStorage.swift */; };
 		500DC5581F1F50B100FE8C3E /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D821C33E1300070AEDC /* Marklight.swift */; };
+		503683F01F208690006A7344 /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683EF1F208690006A7344 /* UniversalTypes.swift */; };
+		503683F11F208690006A7344 /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683EF1F208690006A7344 /* UniversalTypes.swift */; };
 		95C46D6C1C33E11A0070AEDC /* Marklight.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C46D6B1C33E11A0070AEDC /* Marklight.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		95C46D731C33E11A0070AEDC /* Marklight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C46D681C33E11A0070AEDC /* Marklight.framework */; };
 		95C46D781C33E11A0070AEDC /* MarklightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D771C33E11A0070AEDC /* MarklightTests.swift */; };
@@ -41,6 +43,7 @@
 		500DC5451F1F473300FE8C3E /* Marklight macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Marklight macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		500DC54C1F1F473400FE8C3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		500DC5551F1F4BDC00FE8C3E /* Array+appending.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+appending.swift"; sourceTree = "<group>"; };
+		503683EF1F208690006A7344 /* UniversalTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalTypes.swift; sourceTree = "<group>"; };
 		95C46D681C33E11A0070AEDC /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Marklight.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		95C46D6B1C33E11A0070AEDC /* Marklight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Marklight.h; sourceTree = "<group>"; };
 		95C46D6D1C33E11A0070AEDC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -133,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				95C46D821C33E1300070AEDC /* Marklight.swift */,
+				503683EF1F208690006A7344 /* UniversalTypes.swift */,
 				95C46D831C33E1300070AEDC /* MarklightTextStorage.swift */,
 				500DC5551F1F4BDC00FE8C3E /* Array+appending.swift */,
 				95C46D6B1C33E11A0070AEDC /* Marklight.h */,
@@ -328,6 +332,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				503683F11F208690006A7344 /* UniversalTypes.swift in Sources */,
 				500DC5571F1F508500FE8C3E /* MarklightTextStorage.swift in Sources */,
 				500DC5581F1F50B100FE8C3E /* Marklight.swift in Sources */,
 			);
@@ -347,6 +352,7 @@
 				95C46D851C33E1300070AEDC /* MarklightTextStorage.swift in Sources */,
 				500DC5561F1F4BDC00FE8C3E /* Array+appending.swift in Sources */,
 				95C46D841C33E1300070AEDC /* Marklight.swift in Sources */,
+				503683F01F208690006A7344 /* UniversalTypes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Marklight.xcodeproj/project.pbxproj
+++ b/Marklight.xcodeproj/project.pbxproj
@@ -11,8 +11,12 @@
 		500DC5561F1F4BDC00FE8C3E /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500DC5551F1F4BDC00FE8C3E /* Array+appending.swift */; };
 		500DC5571F1F508500FE8C3E /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D831C33E1300070AEDC /* MarklightTextStorage.swift */; };
 		500DC5581F1F50B100FE8C3E /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D821C33E1300070AEDC /* Marklight.swift */; };
+		503683ED1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683EC1F207DCD006A7344 /* MarklightTextProcessor.swift */; };
+		503683EE1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683EC1F207DCD006A7344 /* MarklightTextProcessor.swift */; };
 		503683F01F208690006A7344 /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683EF1F208690006A7344 /* UniversalTypes.swift */; };
 		503683F11F208690006A7344 /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683EF1F208690006A7344 /* UniversalTypes.swift */; };
+		503683F31F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */; };
+		503683F41F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */; };
 		95C46D6C1C33E11A0070AEDC /* Marklight.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C46D6B1C33E11A0070AEDC /* Marklight.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		95C46D731C33E11A0070AEDC /* Marklight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C46D681C33E11A0070AEDC /* Marklight.framework */; };
 		95C46D781C33E11A0070AEDC /* MarklightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D771C33E11A0070AEDC /* MarklightTests.swift */; };
@@ -43,7 +47,9 @@
 		500DC5451F1F473300FE8C3E /* Marklight macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Marklight macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		500DC54C1F1F473400FE8C3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		500DC5551F1F4BDC00FE8C3E /* Array+appending.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+appending.swift"; sourceTree = "<group>"; };
+		503683EC1F207DCD006A7344 /* MarklightTextProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessor.swift; sourceTree = "<group>"; };
 		503683EF1F208690006A7344 /* UniversalTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalTypes.swift; sourceTree = "<group>"; };
+		503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+paragraphRangeAt.swift"; sourceTree = "<group>"; };
 		95C46D681C33E11A0070AEDC /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Marklight.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		95C46D6B1C33E11A0070AEDC /* Marklight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Marklight.h; sourceTree = "<group>"; };
 		95C46D6D1C33E11A0070AEDC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -138,7 +144,9 @@
 				95C46D821C33E1300070AEDC /* Marklight.swift */,
 				503683EF1F208690006A7344 /* UniversalTypes.swift */,
 				95C46D831C33E1300070AEDC /* MarklightTextStorage.swift */,
+				503683EC1F207DCD006A7344 /* MarklightTextProcessor.swift */,
 				500DC5551F1F4BDC00FE8C3E /* Array+appending.swift */,
+				503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */,
 				95C46D6B1C33E11A0070AEDC /* Marklight.h */,
 				95C46D6D1C33E11A0070AEDC /* Info.plist */,
 			);
@@ -332,6 +340,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				503683F41F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */,
+				503683EE1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */,
 				503683F11F208690006A7344 /* UniversalTypes.swift in Sources */,
 				500DC5571F1F508500FE8C3E /* MarklightTextStorage.swift in Sources */,
 				500DC5581F1F50B100FE8C3E /* Marklight.swift in Sources */,
@@ -352,6 +362,8 @@
 				95C46D851C33E1300070AEDC /* MarklightTextStorage.swift in Sources */,
 				500DC5561F1F4BDC00FE8C3E /* Array+appending.swift in Sources */,
 				95C46D841C33E1300070AEDC /* Marklight.swift in Sources */,
+				503683F31F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */,
+				503683ED1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */,
 				503683F01F208690006A7344 /* UniversalTypes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Marklight.xcodeproj/project.pbxproj
+++ b/Marklight.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		503683F11F208690006A7344 /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683EF1F208690006A7344 /* UniversalTypes.swift */; };
 		503683F31F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */; };
 		503683F41F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */; };
+		503683F61F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F51F2095E3006A7344 /* MarklightTextProcessingResult.swift */; };
+		503683F71F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503683F51F2095E3006A7344 /* MarklightTextProcessingResult.swift */; };
 		95C46D6C1C33E11A0070AEDC /* Marklight.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C46D6B1C33E11A0070AEDC /* Marklight.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		95C46D731C33E11A0070AEDC /* Marklight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C46D681C33E11A0070AEDC /* Marklight.framework */; };
 		95C46D781C33E11A0070AEDC /* MarklightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95C46D771C33E11A0070AEDC /* MarklightTests.swift */; };
@@ -50,6 +52,7 @@
 		503683EC1F207DCD006A7344 /* MarklightTextProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessor.swift; sourceTree = "<group>"; };
 		503683EF1F208690006A7344 /* UniversalTypes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UniversalTypes.swift; sourceTree = "<group>"; };
 		503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSString+paragraphRangeAt.swift"; sourceTree = "<group>"; };
+		503683F51F2095E3006A7344 /* MarklightTextProcessingResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessingResult.swift; sourceTree = "<group>"; };
 		95C46D681C33E11A0070AEDC /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Marklight.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		95C46D6B1C33E11A0070AEDC /* Marklight.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Marklight.h; sourceTree = "<group>"; };
 		95C46D6D1C33E11A0070AEDC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -145,6 +148,7 @@
 				503683EF1F208690006A7344 /* UniversalTypes.swift */,
 				95C46D831C33E1300070AEDC /* MarklightTextStorage.swift */,
 				503683EC1F207DCD006A7344 /* MarklightTextProcessor.swift */,
+				503683F51F2095E3006A7344 /* MarklightTextProcessingResult.swift */,
 				500DC5551F1F4BDC00FE8C3E /* Array+appending.swift */,
 				503683F21F2087B0006A7344 /* NSString+paragraphRangeAt.swift */,
 				95C46D6B1C33E11A0070AEDC /* Marklight.h */,
@@ -344,6 +348,7 @@
 				503683EE1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */,
 				503683F11F208690006A7344 /* UniversalTypes.swift in Sources */,
 				500DC5571F1F508500FE8C3E /* MarklightTextStorage.swift in Sources */,
+				503683F71F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */,
 				500DC5581F1F50B100FE8C3E /* Marklight.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -365,6 +370,7 @@
 				503683F31F2087B0006A7344 /* NSString+paragraphRangeAt.swift in Sources */,
 				503683ED1F207DCD006A7344 /* MarklightTextProcessor.swift in Sources */,
 				503683F01F208690006A7344 /* UniversalTypes.swift in Sources */,
+				503683F61F2095E3006A7344 /* MarklightTextProcessingResult.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Marklight/Marklight.swift
+++ b/Marklight/Marklight.swift
@@ -130,22 +130,8 @@
 
 #if os(iOS)
     import UIKit
-
-    typealias MarklightColor = UIColor
-    typealias MarklightFont = UIFont
-    typealias MarklightFontDescriptor = UIFontDescriptor
 #elseif os(macOS)
     import AppKit
-
-    typealias MarklightColor = NSColor
-    typealias MarklightFont = NSFont
-    typealias MarklightFontDescriptor = NSFontDescriptor
-
-    extension NSFont {
-        static func italicSystemFont(ofSize size: CGFloat) -> NSFont {
-            return NSFontManager().convert(NSFont.systemFont(ofSize: size), toHaveTrait: .italicFontMask)
-        }
-    }
 #endif
 
 /**

--- a/Marklight/Marklight.swift
+++ b/Marklight/Marklight.swift
@@ -218,17 +218,18 @@ public struct Marklight {
     // MARK: Processing
     
     /**
-    This function should be called by the `-processEditing` method in your 
-        `NSTextStorage` subclass and this is the function that is being called 
-        for every change in the `UITextView`'s text.
+     This function should be called by the `-processEditing` method in your
+     `NSTextStorage` subclass and this is the function that is being called
+      for every change in the text view's text.
 
-    - parameter textStorage: Your `NSTextStorage` subclass as the highlights
-        will be applied to its attributed string through the `-addAttribute:value:range:` method.
-    - parameter affectedRange: The range of paragraphs to apply styling to.
+     - parameter styleApplier: `MarklightStyleApplier`, for example
+         your `NSTextStorage` subclass.
+     - parameter string: The text that should be scanned for styling.
+     - parameter affectedRange: The range to apply styling to.
     */
-    public static func processEditing(_ textStorage: NSTextStorage, affectedRange paragraphRange: NSRange) {
+    public static func applyMarkdownStyle(_ styleApplier: MarklightStyleApplier, string: String, affectedRange paragraphRange: NSRange) {
 
-        let textStorageNSString = (textStorage.string as NSString)
+        let textStorageNSString = string as NSString
         let wholeRange = NSMakeRange(0, textStorageNSString.length)
 
         let codeFont = Marklight.codeFont(textSize)
@@ -239,76 +240,76 @@ public struct Marklight {
         let hiddenColor = MarklightColor.clear
 
         // We detect and process underlined headers
-        Marklight.headersSetextRegex.matches(textStorage.string, range: wholeRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
+        Marklight.headersSetextRegex.matches(string, range: wholeRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
 
-            Marklight.headersSetextUnderlineRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.headersSetextUnderlineRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
         }
 
         // We detect and process dashed headers
-        Marklight.headersAtxRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
-            Marklight.headersAtxOpeningRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+        Marklight.headersAtxRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
+            Marklight.headersAtxOpeningRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
                     let preRange = NSMakeRange(innerResult!.range.location, innerResult!.range.length + 1)
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
                 }
             }
-            Marklight.headersAtxClosingRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.headersAtxClosingRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
         }
         
         // We detect and process reference links
-        Marklight.referenceLinkRegex.matches(textStorage.string, range: wholeRange) { (result) -> Void in
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: result!.range)
+        Marklight.referenceLinkRegex.matches(string, range: wholeRange) { (result) -> Void in
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: result!.range)
         }
         
         // We detect and process lists
-        Marklight.listRegex.matches(textStorage.string, range: wholeRange) { (result) -> Void in
-            Marklight.listOpeningRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+        Marklight.listRegex.matches(string, range: wholeRange) { (result) -> Void in
+            Marklight.listOpeningRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
         }
         
         // We detect and process anchors (links)
-        Marklight.anchorRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
-            Marklight.openingSquareRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+        Marklight.anchorRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
+            Marklight.openingSquareRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
-            Marklight.closingSquareRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.closingSquareRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
-            Marklight.parenRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.parenRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
                     let preRange = NSMakeRange(innerResult!.range.location, 1)
                     let postRange = NSMakeRange(innerResult!.range.location + innerResult!.range.length - 1, 1)
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
                 }
             }
         }
         
         // We detect and process inline anchors (links)
-        Marklight.anchorInlineRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
+        Marklight.anchorInlineRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
             
             var destinationLink : String?
             
-            Marklight.coupleRoundRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.coupleRoundRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 
                 var range = innerResult!.range
                 range.location = range.location + 1
@@ -318,33 +319,33 @@ public struct Marklight {
                 guard substring.lengthOfBytes(using: .utf8) > 0 else { return }
 
                 destinationLink = substring
-                textStorage.addAttribute(NSLinkAttributeName, value: substring, range: range)
+                styleApplier.addAttribute(NSLinkAttributeName, value: substring, range: range)
                 
                 if Marklight.hideSyntax {
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
             
-            Marklight.openingSquareRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.openingSquareRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
             
-            Marklight.closingSquareRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.closingSquareRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
             
             guard let destinationLinkString = destinationLink else { return }
             
-            Marklight.coupleSquareRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
+            Marklight.coupleSquareRegex.matches(string, range: result!.range) { (innerResult) -> Void in
                 var range = innerResult!.range
                 range.location = range.location + 1
                 range.length = range.length - 2
@@ -352,88 +353,88 @@ public struct Marklight {
                 let substring = textStorageNSString.substring(with: range)
                 guard substring.lengthOfBytes(using: .utf8) > 0 else { return }
                 
-                textStorage.addAttribute(NSLinkAttributeName, value: destinationLinkString, range: range)
+                styleApplier.addAttribute(NSLinkAttributeName, value: destinationLinkString, range: range)
             }
         }
         
-        Marklight.imageRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
+        Marklight.imageRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
             
             // TODO: add image attachment
             if Marklight.hideSyntax {
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: result!.range)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: result!.range)
             }
-            Marklight.imageOpeningSquareRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.imageOpeningSquareRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
-            Marklight.imageClosingSquareRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.imageClosingSquareRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
         }
         
         // We detect and process inline images
-        Marklight.imageInlineRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
+        Marklight.imageInlineRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
 
             // TODO: add image attachment
             if Marklight.hideSyntax {
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: result!.range)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: result!.range)
             }
-            Marklight.imageOpeningSquareRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.imageOpeningSquareRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
-            Marklight.imageClosingSquareRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.imageClosingSquareRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
-            Marklight.parenRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.parenRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
             }
         }
         
         // We detect and process inline code
-        Marklight.codeSpanRegex.matches(textStorage.string, range: wholeRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: codeColor, range: result!.range)
+        Marklight.codeSpanRegex.matches(string, range: wholeRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: codeColor, range: result!.range)
             
-            Marklight.codeSpanOpeningRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.codeSpanOpeningRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
-            Marklight.codeSpanClosingRegex.matches(textStorage.string, range: paragraphRange) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+            Marklight.codeSpanClosingRegex.matches(string, range: paragraphRange) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
         }
         
         // We detect and process code blocks
-        Marklight.codeBlockRegex.matches(textStorage.string, range: wholeRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: codeColor, range: result!.range)
+        Marklight.codeBlockRegex.matches(string, range: wholeRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: codeFont, range: result!.range)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: codeColor, range: result!.range)
         }
         
         // We detect and process quotes
-        Marklight.blockQuoteRegex.matches(textStorage.string, range: wholeRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: quoteFont, range: result!.range)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: quoteColor, range: result!.range)
-            textStorage.addAttribute(NSParagraphStyleAttributeName, value: quoteIndendationStyle, range: result!.range)
-            Marklight.blockQuoteOpeningRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
+        Marklight.blockQuoteRegex.matches(string, range: wholeRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: quoteFont, range: result!.range)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: quoteColor, range: result!.range)
+            styleApplier.addAttribute(NSParagraphStyleAttributeName, value: quoteIndendationStyle, range: result!.range)
+            Marklight.blockQuoteOpeningRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: innerResult!.range)
                 if Marklight.hideSyntax {
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
         }
 
         // We detect and process strict italics
-        Marklight.strictItalicRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: italicFont, range: result!.range)
+        Marklight.strictItalicRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: italicFont, range: result!.range)
             let substring = textStorageNSString.substring(with: NSMakeRange(result!.range.location, 1))
             var start = 0
             if substring == " " {
@@ -441,19 +442,19 @@ public struct Marklight {
             }
             let preRange = NSMakeRange(result!.range.location + start, 1)
             let postRange = NSMakeRange(result!.range.location + result!.range.length - 1, 1)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
             if Marklight.hideSyntax {
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
             }
         }
         
         // We detect and process strict bolds
-        Marklight.strictBoldRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
+        Marklight.strictBoldRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
             let substring = textStorageNSString.substring(with: NSMakeRange(result!.range.location, 1))
             var start = 0
             if substring == " " {
@@ -461,70 +462,70 @@ public struct Marklight {
             }
             let preRange = NSMakeRange(result!.range.location + start, 2)
             let postRange = NSMakeRange(result!.range.location + result!.range.length - 2, 2)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
             if Marklight.hideSyntax {
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
             }
         }
 
         // We detect and process italics
-        Marklight.italicRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: italicFont, range: result!.range)
+        Marklight.italicRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: italicFont, range: result!.range)
             let preRange = NSMakeRange(result!.range.location, 1)
             let postRange = NSMakeRange(result!.range.location + result!.range.length - 1, 1)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
             if Marklight.hideSyntax {
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
             }
         }
         
         // We detect and process bolds
-        Marklight.boldRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
-            textStorage.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
+        Marklight.boldRegex.matches(string, range: paragraphRange) { (result) -> Void in
+            styleApplier.addAttribute(NSFontAttributeName, value: boldFont, range: result!.range)
             let preRange = NSMakeRange(result!.range.location, 2)
             let postRange = NSMakeRange(result!.range.location + result!.range.length - 2, 2)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
-            textStorage.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: preRange)
+            styleApplier.addAttribute(NSForegroundColorAttributeName, value: Marklight.syntaxColor, range: postRange)
             if Marklight.hideSyntax {
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
-                textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
-                textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: preRange)
+                styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: postRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: preRange)
+                styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: postRange)
             }
         }
 
         // We detect and process inline links not formatted
-        Marklight.autolinkRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
+        Marklight.autolinkRegex.matches(string, range: paragraphRange) { (result) -> Void in
             let substring = textStorageNSString.substring(with: result!.range)
             guard substring.lengthOfBytes(using: .utf8) > 0 else { return }
-            textStorage.addAttribute(NSLinkAttributeName, value: substring, range: result!.range)
+            styleApplier.addAttribute(NSLinkAttributeName, value: substring, range: result!.range)
             
             if Marklight.hideSyntax {
-                Marklight.autolinkPrefixRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                Marklight.autolinkPrefixRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
         }
         
         // We detect and process inline mailto links not formatted
-        Marklight.autolinkEmailRegex.matches(textStorage.string, range: paragraphRange) { (result) -> Void in
+        Marklight.autolinkEmailRegex.matches(string, range: paragraphRange) { (result) -> Void in
             let substring = textStorageNSString.substring(with: result!.range)
             guard substring.lengthOfBytes(using: .utf8) > 0 else { return }
-            textStorage.addAttribute(NSLinkAttributeName, value: substring, range: result!.range)
+            styleApplier.addAttribute(NSLinkAttributeName, value: substring, range: result!.range)
             
             if Marklight.hideSyntax {
-                Marklight.mailtoRegex.matches(textStorage.string, range: result!.range) { (innerResult) -> Void in
-                    textStorage.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
-                    textStorage.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
+                Marklight.mailtoRegex.matches(string, range: result!.range) { (innerResult) -> Void in
+                    styleApplier.addAttribute(NSFontAttributeName, value: hiddenFont, range: innerResult!.range)
+                    styleApplier.addAttribute(NSForegroundColorAttributeName, value: hiddenColor, range: innerResult!.range)
                 }
             }
         }

--- a/Marklight/MarklightStyleApplier.swift
+++ b/Marklight/MarklightStyleApplier.swift
@@ -1,0 +1,29 @@
+//
+//  MarklightStyleApplier
+//  Marklight
+//
+//  Created by Christian Tietze on 2017-07-20.
+//  Copyright © 2017 MacTeo. See LICENSE for details.
+//
+
+#if os(iOS)
+    import UIKit
+#elseif os(macOS)
+    import AppKit
+#endif
+
+public protocol MarklightStyleApplier {
+    func addAttribute(_ name: String, value: Any, range: NSRange)
+    func addAttributes(_ attrs: [String : Any], range: NSRange)
+    func removeAttribute(_ name: String, range: NSRange)
+    func resetMarklightTextAttributes(textSize: CGFloat, range: NSRange)
+}
+
+extension NSTextStorage: MarklightStyleApplier {
+    public func resetMarklightTextAttributes(textSize: CGFloat, range: NSRange) {
+        self.removeAttribute(NSForegroundColorAttributeName, range: range)
+        self.addAttribute(NSFontAttributeName, value: MarklightFont.systemFont(ofSize: textSize), range: range)
+        self.addAttribute(NSParagraphStyleAttributeName, value: NSParagraphStyle(), range: range)
+    }
+}
+

--- a/Marklight/MarklightTextProcessingResult.swift
+++ b/Marklight/MarklightTextProcessingResult.swift
@@ -1,0 +1,45 @@
+//
+//  MarklightTextProcessingResult
+//  Marklight
+//
+//  Created by Christian Tietze on 2017-07-20.
+//  Copyright © 2017 MacTeo. See LICENSE for details.
+//
+
+#if os(iOS)
+    import UIKit
+#elseif os(macOS)
+    import AppKit
+#endif
+
+public struct MarklightProcessingResult {
+    public let editedRange: NSRange
+    public let affectedRange: NSRange
+
+    public init(editedRange: NSRange, affectedRange: NSRange) {
+
+        self.editedRange = editedRange
+        self.affectedRange = affectedRange
+    }
+
+    public func updateLayoutManagers(for textStorage: NSTextStorage) {
+
+        textStorage.layoutManagers.forEach {
+            $0.processEditing(
+                for: textStorage,
+                processingResult: self)
+        }
+    }
+}
+
+extension NSLayoutManager {
+    func processEditing(for textStorage: NSTextStorage, processingResult: MarklightProcessingResult) {
+
+        self.processEditing(
+            for: textStorage,
+            edited: .editedAttributes,
+            range: processingResult.editedRange,
+            changeInLength: 0,
+            invalidatedRange: processingResult.affectedRange)
+    }
+}

--- a/Marklight/MarklightTextProcessor.swift
+++ b/Marklight/MarklightTextProcessor.swift
@@ -1,0 +1,229 @@
+//
+//  MarklightTextProcessor
+//  Marklight
+//
+//  Created by Christian Tietze on 2017-07-20.
+//  Copyright © 2017 MacTeo. LICENSE for details.
+//
+
+#if os(iOS)
+    import UIKit
+#elseif os(macOS)
+    import AppKit
+#endif
+
+extension NSTextStorage {
+    func resetMarklightTextAttributes(textSize: CGFloat, range: NSRange) {
+        self.removeAttribute(NSForegroundColorAttributeName, range: range)
+        self.addAttribute(NSFontAttributeName, value: MarklightFont.systemFont(ofSize: textSize), range: range)
+        self.addAttribute(NSParagraphStyleAttributeName, value: NSParagraphStyle(), range: range)
+    }
+
+    #if os(iOS)
+    func invalidateTextSizeForWholeRange() {
+        let wholeRange = NSMakeRange(0, (self.string as NSString).length)
+        self.invalidateAttributes(in: wholeRange)
+        for layoutManager in self.layoutManagers {
+            layoutManager.invalidateDisplay(forCharacterRange: wholeRange)
+        }
+    }
+    #endif
+}
+
+public struct MarklightProcessingResult {
+    public let editedRange: NSRange
+    public let affectedRange: NSRange
+
+    public init(editedRange: NSRange, affectedRange: NSRange) {
+
+        self.editedRange = editedRange
+        self.affectedRange = affectedRange
+    }
+}
+
+open class MarklightTextProcessor {
+
+    let textStorage: NSTextStorage
+
+    open var string : String { return textStorage.string }
+
+    public init(textStorage: NSTextStorage) {
+        self.textStorage = textStorage
+
+        #if os(iOS)
+            observeTextSize()
+        #endif
+    }
+
+    // MARK: Syntax highlight customisation
+
+    /**
+     Color used to highlight markdown syntax. Default value is light grey.
+     */
+    open var syntaxColor = MarklightColor.lightGray
+
+    /**
+     Font used for blocks and inline code. Default value is *Menlo*.
+     */
+    open var codeFontName = "Menlo"
+
+    /**
+     `MarklightColor` used for blocks and inline code. Default value is dark grey.
+     */
+    open var codeColor = MarklightColor.darkGray
+
+    /**
+     Font used for quote blocks. Default value is *Menlo*.
+     */
+    open var quoteFontName = "Menlo"
+
+    /**
+     `MarklightColor` used for quote blocks. Default value is dark grey.
+     */
+    open var quoteColor = MarklightColor.darkGray
+
+    /**
+     Quote indentation in points. Default 20.
+     */
+    open var quoteIndendation : CGFloat = 20
+
+    /**
+     If the markdown syntax should be hidden or visible
+     */
+    open var hideSyntax = false
+
+
+    // MARK: Syntax highlighting
+
+    open func processEditing(
+        editedRange: NSRange
+        ) -> MarklightProcessingResult {
+
+        let editedAndAdjacentParagraphRange = self.editedAndAdjacentParagraphRange(editedRange: editedRange)
+        let editedParagraphRange = self.editedParagraphRange(editedRange: editedRange)
+
+        resetMarklightAttributes(range: editedAndAdjacentParagraphRange)
+
+        Marklight.syntaxColor = syntaxColor
+        Marklight.codeFontName = codeFontName
+        Marklight.codeColor = codeColor
+        Marklight.quoteFontName = quoteFontName
+        Marklight.quoteColor = quoteColor
+        Marklight.quoteIndendation = quoteIndendation
+        Marklight.textSize = textSize
+        Marklight.hideSyntax = hideSyntax
+
+        Marklight.processEditing(self.textStorage, affectedRange: editedAndAdjacentParagraphRange)
+
+        return MarklightProcessingResult(
+            editedRange: editedRange,
+            affectedRange: editedAndAdjacentParagraphRange)
+    }
+
+    fileprivate func editedParagraphRange(editedRange: NSRange) -> NSRange {
+        return (self.string as NSString).paragraphRange(for: editedRange)
+    }
+
+    fileprivate func editedAndAdjacentParagraphRange(editedRange: NSRange) -> NSRange {
+        let textStorageNSString = (self.string as NSString)
+        let editedParagraphRange = textStorageNSString.paragraphRange(for: editedRange)
+
+        let previousParagraphRange: NSRange
+        if editedParagraphRange.location > 0 {
+            previousParagraphRange = textStorageNSString.paragraphRange(at: editedParagraphRange.location - 1)
+        } else {
+            previousParagraphRange = NSRange(location: editedParagraphRange.location, length: 0)
+        }
+
+        let nextParagraphRange: NSRange
+        let locationAfterEditedParagraph = editedParagraphRange.location + editedParagraphRange.length
+        if locationAfterEditedParagraph < textStorageNSString.length {
+            nextParagraphRange = textStorageNSString.paragraphRange(at: locationAfterEditedParagraph + 1)
+        } else {
+            nextParagraphRange = NSRange.init(location: 0, length: 0)
+        }
+
+        return NSRange(
+            location: previousParagraphRange.location,
+            length: [previousParagraphRange, editedParagraphRange, nextParagraphRange].map { $0.length }.reduce(0, +))
+    }
+
+    fileprivate func resetMarklightAttributes(range: NSRange) {
+
+        textStorage.resetMarklightTextAttributes(
+            textSize: self.textSize,
+            range: range)
+    }
+
+    #if os(iOS)
+
+    /**
+     Internal method to register to notifications determined by dynamic type size
+     changes and redraw the attributed text with the appropriate text size.
+     Currently it works only after the user adds or removes some chars inside the
+     `UITextView`.
+     */
+    func observeTextSize() {
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIContentSizeCategoryDidChange, object: nil, queue: OperationQueue.main) { [weak self] (notification) -> Void in
+            self?.textStorage.invalidateTextSizeForWholeRange()
+        }
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: Font Style Settings
+
+    /**
+     Dynamic type font text style, default `UIFontTextStyleBody`.
+
+     - see: [Text Styles](xcdoc://?url=developer.apple.com/library/ios/documentation/UIKit/Reference/UIFontDescriptor_Class/index.html#//apple_ref/doc/constant_group/Text_Styles)
+     */
+    open var fontTextStyle : String = UIFontTextStyle.body.rawValue
+
+    /// Text size measured in points.
+    fileprivate var textSize: CGFloat {
+        return MarklightFontDescriptor
+            .preferredFontDescriptor(withTextStyle: UIFontTextStyle(rawValue: self.fontTextStyleValidated))
+            .pointSize
+    }
+
+    // We are validating the user provided fontTextStyle `String` to match the
+    // system supported ones.
+    fileprivate var fontTextStyleValidated : String {
+
+        let supportedTextStyles: [String] = {
+
+            let baseStyles = [
+                UIFontTextStyle.headline.rawValue,
+                UIFontTextStyle.subheadline.rawValue,
+                UIFontTextStyle.body.rawValue,
+                UIFontTextStyle.footnote.rawValue,
+                UIFontTextStyle.caption1.rawValue,
+                UIFontTextStyle.caption2.rawValue
+            ]
+
+            guard #available(iOS 9.0, *) else { return baseStyles }
+
+            return baseStyles.appending(contentsOf: [
+                UIFontTextStyle.title1.rawValue,
+                UIFontTextStyle.title2.rawValue,
+                UIFontTextStyle.title3.rawValue,
+                UIFontTextStyle.callout.rawValue
+                ])
+        }()
+        
+        guard supportedTextStyles.contains(self.fontTextStyle) else {
+            return UIFontTextStyle.body.rawValue
+        }
+        
+        return self.fontTextStyle
+    }
+
+    #elseif os(macOS)
+
+    open var textSize: CGFloat = NSFont.systemFontSize()
+
+    #endif
+}

--- a/Marklight/MarklightTextProcessor.swift
+++ b/Marklight/MarklightTextProcessor.swift
@@ -20,38 +20,6 @@ extension NSTextStorage {
     }
 }
 
-extension NSLayoutManager {
-    func processEditing(for textStorage: NSTextStorage, processingResult: MarklightProcessingResult) {
-
-        self.processEditing(
-            for: textStorage,
-            edited: .editedAttributes,
-            range: processingResult.editedRange,
-            changeInLength: 0,
-            invalidatedRange: processingResult.affectedRange)
-    }
-}
-
-public struct MarklightProcessingResult {
-    public let editedRange: NSRange
-    public let affectedRange: NSRange
-
-    public init(editedRange: NSRange, affectedRange: NSRange) {
-
-        self.editedRange = editedRange
-        self.affectedRange = affectedRange
-    }
-
-    public func updateLayoutManagers(for textStorage: NSTextStorage) {
-
-        textStorage.layoutManagers.forEach {
-            $0.processEditing(
-                for: textStorage,
-                processingResult: self)
-        }
-    }
-}
-
 open class MarklightTextProcessor {
 
     // MARK: Syntax highlight customisation

--- a/Marklight/MarklightTextProcessor.swift
+++ b/Marklight/MarklightTextProcessor.swift
@@ -99,7 +99,7 @@ open class MarklightTextProcessor {
         let nextParagraphRange: NSRange
         let locationAfterEditedParagraph = editedParagraphRange.location + editedParagraphRange.length
         if locationAfterEditedParagraph < nsString.length {
-            nextParagraphRange = nsString.paragraphRange(at: locationAfterEditedParagraph + 1)
+            nextParagraphRange = nsString.paragraphRange(at: locationAfterEditedParagraph)
         } else {
             nextParagraphRange = NSRange.init(location: 0, length: 0)
         }

--- a/Marklight/MarklightTextProcessor.swift
+++ b/Marklight/MarklightTextProcessor.swift
@@ -100,7 +100,6 @@ open class MarklightTextProcessor {
         ) -> MarklightProcessingResult {
 
         let editedAndAdjacentParagraphRange = self.editedAndAdjacentParagraphRange(editedRange: editedRange)
-        let editedParagraphRange = self.editedParagraphRange(editedRange: editedRange)
 
         resetMarklightAttributes(range: editedAndAdjacentParagraphRange)
 
@@ -118,10 +117,6 @@ open class MarklightTextProcessor {
         return MarklightProcessingResult(
             editedRange: editedRange,
             affectedRange: editedAndAdjacentParagraphRange)
-    }
-
-    fileprivate func editedParagraphRange(editedRange: NSRange) -> NSRange {
-        return (self.string as NSString).paragraphRange(for: editedRange)
     }
 
     fileprivate func editedAndAdjacentParagraphRange(editedRange: NSRange) -> NSRange {

--- a/Marklight/MarklightTextStorage.swift
+++ b/Marklight/MarklightTextStorage.swift
@@ -104,9 +104,9 @@ open class MarklightTextStorage: NSTextStorage {
         defer { self.isBusyProcessing = false }
 
         let processingResult = marklightTextProcessor.processEditing(
-            textStorage: self,
-            editedRange: editedRange,
-            string: self.string)
+            styleApplier: self,
+            string: self.string,
+            editedRange: editedRange)
 
         defer {
             // Include surrounding paragraphs in layout manager's styling pass
@@ -117,7 +117,9 @@ open class MarklightTextStorage: NSTextStorage {
         super.processEditing()
     }
 
-    override func resetMarklightTextAttributes(textSize: CGFloat, range: NSRange) {
+    override public func resetMarklightTextAttributes(textSize: CGFloat, range: NSRange) {
+        // Use `imp` directly instead of `self` to avoid changing the edited range
+        // after attribute fixing, affecting the insertion point on macOS.
         imp.removeAttribute(NSForegroundColorAttributeName, range: range)
         imp.addAttribute(NSFontAttributeName, value: MarklightFont.systemFont(ofSize: textSize), range: range)
         imp.addAttribute(NSParagraphStyleAttributeName, value: NSParagraphStyle(), range: range)

--- a/Marklight/MarklightTextStorage.swift
+++ b/Marklight/MarklightTextStorage.swift
@@ -11,9 +11,15 @@
     import AppKit
 #endif
 
-extension NSString {
-    func paragraphRange(at location: Int) -> NSRange {
-        return paragraphRange(for: NSRange(location: location, length: 0))
+extension NSLayoutManager {
+    func processEditing(for textStorage: NSTextStorage, processingResult: MarklightProcessingResult) {
+
+        self.processEditing(
+            for: textStorage,
+            edited: .editedAttributes,
+            range: processingResult.editedRange,
+            changeInLength: 0,
+            invalidatedRange: processingResult.affectedRange)
     }
 }
 
@@ -78,47 +84,13 @@ extension NSString {
 
 open class MarklightTextStorage: NSTextStorage {
 
+    open weak var marklightTextProcessor: MarklightTextProcessor?
+
     /// Delegate from this class cluster to a regular `NSTextStorage` instance
     /// because it does some additional performance optimizations 
     /// over `NSMutableAttributedString`.
     fileprivate let imp = NSTextStorage()
-    
-    // MARK: Syntax highlight customisation
-    
-    /**
-    Color used to highlight markdown syntax. Default value is light grey.
-    */
-    open var syntaxColor = MarklightColor.lightGray
-    
-    /**
-     Font used for blocks and inline code. Default value is *Menlo*.
-     */
-    open var codeFontName = "Menlo"
-    
-    /**
-     `MarklightColor` used for blocks and inline code. Default value is dark grey.
-     */
-    open var codeColor = MarklightColor.darkGray
-    
-    /**
-     Font used for quote blocks. Default value is *Menlo*.
-     */
-    open var quoteFontName = "Menlo"
-    
-    /**
-     `MarklightColor` used for quote blocks. Default value is dark grey.
-     */
-    open var quoteColor = MarklightColor.darkGray
-    
-    /**
-     Quote indentation in points. Default 20.
-     */
-    open var quoteIndendation : CGFloat = 20
-   
-    /**
-     If the markdown syntax should be hidden or visible
-     */
-    open var hideSyntax = false
+
         
     // MARK: Syntax highlighting
 
@@ -128,8 +100,7 @@ open class MarklightTextStorage: NSTextStorage {
 
     /**
     To customise the appearance of the markdown syntax highlights you should
-     subclass this class (or create your own direct `NSTextStorage` subclass)
-     and set the customisations in this method implementation. Sends out
+     subclass `MarklightTextProcessor`. Sends out
      `-textStorage:willProcessEditing`, fixes the attributes, sends out
      `-textStorage:didProcessEditing`, and notifies the layout managers of
      change with the
@@ -144,81 +115,27 @@ open class MarklightTextStorage: NSTextStorage {
         self.isBusyProcessing = true
         defer { self.isBusyProcessing = false }
 
-        let editedAndAdjacentParagraphRange = self.editedAndAdjacentParagraphRange
-        let editedParagraphRange = self.editedParagraphRange
-        defer {
-            // Include surrounding paragraphs in layout manager's styling pass
-            // after finishing the real edit. Mostly needed for Setex headings.
-            layoutManagers.first?.processEditing(
-                for: self,
-                edited: .editedAttributes,
-                range: editedRange,
-                changeInLength: 0,
-                invalidatedRange: editedAndAdjacentParagraphRange)
+        if let marklightTextProcessor = marklightTextProcessor {
+            let processingResult = marklightTextProcessor.processEditing(editedRange: self.editedRange)
+
+            defer {
+                // Include surrounding paragraphs in layout manager's styling pass
+                // after finishing the real edit. Mostly needed for Setex headings.
+                self.layoutManagers.forEach {
+                    $0.processEditing(
+                        for: self,
+                        processingResult: processingResult)
+                }
+            }
         }
-
-        resetMarklightAttributes(range: editedAndAdjacentParagraphRange)
-//        removeParagraphAttributes()
-//        removeWholeAttributes()
-
-        Marklight.syntaxColor = syntaxColor
-        Marklight.codeFontName = codeFontName
-        Marklight.codeColor = codeColor
-        Marklight.quoteFontName = quoteFontName
-        Marklight.quoteColor = quoteColor
-        Marklight.quoteIndendation = quoteIndendation
-        Marklight.textSize = textSize
-        Marklight.hideSyntax = hideSyntax
-        
-        Marklight.processEditing(self, affectedRange: editedAndAdjacentParagraphRange)
 
         super.processEditing()
     }
 
-    fileprivate var editedParagraphRange: NSRange {
-        return (self.string as NSString).paragraphRange(for: self.editedRange)
-    }
-
-    fileprivate var editedAndAdjacentParagraphRange: NSRange {
-        let textStorageNSString = (self.string as NSString)
-        let editedParagraphRange = textStorageNSString.paragraphRange(for: self.editedRange)
-
-        let previousParagraphRange: NSRange
-        if editedParagraphRange.location > 0 {
-            previousParagraphRange = textStorageNSString.paragraphRange(at: editedParagraphRange.location - 1)
-        } else {
-            previousParagraphRange = NSRange(location: editedParagraphRange.location, length: 0)
-        }
-
-        let nextParagraphRange: NSRange
-        let locationAfterEditedParagraph = editedParagraphRange.location + editedParagraphRange.length
-        if locationAfterEditedParagraph < textStorageNSString.length {
-            nextParagraphRange = textStorageNSString.paragraphRange(at: locationAfterEditedParagraph + 1)
-        } else {
-            nextParagraphRange = NSRange.init(location: 0, length: 0)
-        }
-
-        return NSRange(
-            location: previousParagraphRange.location,
-            length: [previousParagraphRange, editedParagraphRange, nextParagraphRange].map { $0.length }.reduce(0, +))
-    }
-
-    fileprivate func resetMarklightAttributes(range: NSRange) {
+    override func resetMarklightTextAttributes(textSize: CGFloat, range: NSRange) {
         imp.removeAttribute(NSForegroundColorAttributeName, range: range)
         imp.addAttribute(NSFontAttributeName, value: MarklightFont.systemFont(ofSize: textSize), range: range)
         imp.addAttribute(NSParagraphStyleAttributeName, value: NSParagraphStyle(), range: range)
-    }
-
-    // Remove every attribute the the paragraph containing the last edit.
-    fileprivate func removeParagraphAttributes() {
-        let paragraphRange = (string as NSString).paragraphRange(for: self.editedRange)
-        resetMarklightAttributes(range: paragraphRange)
-    }
-
-    // Remove every attribute to the whole text
-    fileprivate func removeWholeAttributes() {
-        let wholeRange = NSMakeRange(0, (self.string as NSString).length)
-        resetMarklightAttributes(range: wholeRange)
     }
 
 
@@ -313,102 +230,4 @@ open class MarklightTextStorage: NSTextStorage {
         edited([.editedAttributes], range: range, changeInLength: 0)
         endEditing()
     }
-
-    // MARK: - iOS-Only Font Text Style Support
-
-    #if os(iOS)
-
-    // MARK: Initialisers
-
-    /**
-     The designated initialiser. If you subclass `MarklightTextStorage`, you
-     must call the super implementation of this method.
-     */
-    override public init() {
-        super.init()
-        observeTextSize()
-    }
-
-    /**
-     The designated initialiser. If you subclass `MarklightTextStorage`, you must
-     call the super implementation of this method.
-     */
-    required public init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        observeTextSize()
-    }
-
-    /**
-     Internal method to register to notifications determined by dynamic type size
-     changes and redraw the attributed text with the appropriate text size.
-     Currently it works only after the user adds or removes some chars inside the
-     `UITextView`.
-     */
-    func observeTextSize() {
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIContentSizeCategoryDidChange, object: nil, queue: OperationQueue.main) { (notification) -> Void in
-            let wholeRange = NSMakeRange(0, (self.string as NSString).length)
-            self.invalidateAttributes(in: wholeRange)
-            for layoutManager in self.layoutManagers {
-                layoutManager.invalidateDisplay(forCharacterRange: wholeRange)
-            }
-        }
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-    // MARK: Font Style Settings
-
-    /**
-     Dynamic type font text style, default `UIFontTextStyleBody`.
-
-     - see: [Text Styles](xcdoc://?url=developer.apple.com/library/ios/documentation/UIKit/Reference/UIFontDescriptor_Class/index.html#//apple_ref/doc/constant_group/Text_Styles)
-     */
-    open var fontTextStyle : String = UIFontTextStyle.body.rawValue
-
-    /// Text size measured in points.
-    fileprivate var textSize: CGFloat {
-        return MarklightFontDescriptor
-            .preferredFontDescriptor(withTextStyle: UIFontTextStyle(rawValue: self.fontTextStyleValidated))
-            .pointSize
-    }
-
-    // We are validating the user provided fontTextStyle `String` to match the
-    // system supported ones.
-    fileprivate var fontTextStyleValidated : String {
-
-        let supportedTextStyles: [String] = {
-
-            let baseStyles = [
-                UIFontTextStyle.headline.rawValue,
-                UIFontTextStyle.subheadline.rawValue,
-                UIFontTextStyle.body.rawValue,
-                UIFontTextStyle.footnote.rawValue,
-                UIFontTextStyle.caption1.rawValue,
-                UIFontTextStyle.caption2.rawValue
-            ]
-
-            guard #available(iOS 9.0, *) else { return baseStyles }
-
-            return baseStyles.appending(contentsOf: [
-                UIFontTextStyle.title1.rawValue,
-                UIFontTextStyle.title2.rawValue,
-                UIFontTextStyle.title3.rawValue,
-                UIFontTextStyle.callout.rawValue
-                ])
-        }()
-
-        guard supportedTextStyles.contains(self.fontTextStyle) else {
-            return UIFontTextStyle.body.rawValue
-        }
-        
-        return self.fontTextStyle
-    }
-
-    #elseif os(macOS)
-
-    open var textSize: CGFloat = NSFont.systemFontSize()
-
-    #endif
 }

--- a/Marklight/NSString+paragraphRangeAt.swift
+++ b/Marklight/NSString+paragraphRangeAt.swift
@@ -1,0 +1,15 @@
+//
+//  NSString+paragraphRangeAt.swift
+//  Marklight
+//
+//  Created by Christian Tietze on 20.07.17.
+//  Copyright © 2017 MacTeo. See LICENSE for details.
+//
+
+import Foundation
+
+extension NSString {
+    func paragraphRange(at location: Int) -> NSRange {
+        return paragraphRange(for: NSRange(location: location, length: 0))
+    }
+}

--- a/Marklight/UniversalTypes.swift
+++ b/Marklight/UniversalTypes.swift
@@ -1,0 +1,28 @@
+//
+//  UniversalTypes.swift
+//  Marklight
+//
+//  Created by Christian Tietze on 20.07.17.
+//  Copyright © 2017 MacTeo. See LICENSE for details.
+//
+
+#if os(iOS)
+    import UIKit
+
+    typealias MarklightColor = UIColor
+    typealias MarklightFont = UIFont
+    typealias MarklightFontDescriptor = UIFontDescriptor
+#elseif os(macOS)
+    import AppKit
+
+
+    typealias MarklightColor = NSColor
+    typealias MarklightFont = NSFont
+    typealias MarklightFontDescriptor = NSFontDescriptor
+
+    extension NSFont {
+        static func italicSystemFont(ofSize size: CGFloat) -> NSFont {
+            return NSFontManager().convert(NSFont.systemFont(ofSize: size), toHaveTrait: .italicFontMask)
+        }
+    }
+#endif

--- a/MarklightTests/MarklightTextProcessorTests.swift
+++ b/MarklightTests/MarklightTextProcessorTests.swift
@@ -4,9 +4,13 @@
 import XCTest
 @testable import Marklight
 
-extension NSRange: Equatable {
+extension NSRange: Equatable, CustomStringConvertible {
     public static func ==(lhs: NSRange, rhs: NSRange) -> Bool {
         return lhs.location == rhs.location && lhs.length == rhs.length
+    }
+
+    public var description: String {
+        return "NSRange(\(location), \(length))"
     }
 }
 
@@ -73,6 +77,24 @@ class MarklightTextProcessorTests: XCTestCase {
         let result = MarklightTextProcessor().processEditing(styleApplier: styleApplierDouble, string: string, editedRange: editedRange)
 
         let expectedAffectedRange = NSRange(location: 0, length: 4)
+        XCTAssertNotNil(styleApplierDouble.didResetMarklightTextAttributes)
+        if let values = styleApplierDouble.didResetMarklightTextAttributes {
+            XCTAssertEqual(values.range, expectedAffectedRange)
+        }
+
+        XCTAssertEqual(result.editedRange, editedRange)
+        XCTAssertEqual(result.affectedRange, expectedAffectedRange)
+    }
+
+    func testProcess_EditedLineWithEmptyLinesAround_ResetsAttributesForEmptyLines() {
+
+        let string = "_\n\nxx\n\n_\n"
+        //               ^ ^^^ ^
+        let editedRange = NSRange(location: 4, length: 0)
+
+        let result = MarklightTextProcessor().processEditing(styleApplier: styleApplierDouble, string: string, editedRange: editedRange)
+
+        let expectedAffectedRange = NSRange(location: 2, length: 5)
         XCTAssertNotNil(styleApplierDouble.didResetMarklightTextAttributes)
         if let values = styleApplierDouble.didResetMarklightTextAttributes {
             XCTAssertEqual(values.range, expectedAffectedRange)

--- a/MarklightTests/MarklightTextProcessorTests.swift
+++ b/MarklightTests/MarklightTextProcessorTests.swift
@@ -1,0 +1,102 @@
+//  Created by Christian Tietze on 2017-07-20.
+//  Copyright © 2017 MacTeo. See LICENSE for details.
+
+import XCTest
+@testable import Marklight
+
+extension NSRange: Equatable {
+    public static func ==(lhs: NSRange, rhs: NSRange) -> Bool {
+        return lhs.location == rhs.location && lhs.length == rhs.length
+    }
+}
+
+class MarklightTextProcessorTests: XCTestCase {
+
+    class StyleApplierDouble: MarklightStyleApplier {
+        var didAddAttributes: (attributes: [String : Any], range: NSRange)?
+        func addAttributes(_ attrs: [String : Any], range: NSRange) {
+            didAddAttributes = (attrs, range)
+        }
+
+        var didAddAttribute: (name: String, value: Any, range: NSRange)?
+        func addAttribute(_ name: String, value: Any, range: NSRange) {
+            didAddAttribute = (name, value, range)
+        }
+
+        var didRemoveAttribute: (name: String, range: NSRange)?
+        func removeAttribute(_ name: String, range: NSRange) {
+            didRemoveAttribute = (name, range)
+        }
+
+        var didResetMarklightTextAttributes: (textSize: CGFloat, range: NSRange)?
+        func resetMarklightTextAttributes(textSize: CGFloat, range: NSRange) {
+            didResetMarklightTextAttributes = (textSize, range)
+        }
+    }
+
+    var styleApplierDouble: StyleApplierDouble!
+
+    override func setUp() {
+        super.setUp()
+        styleApplierDouble = StyleApplierDouble()
+    }
+    
+    override func tearDown() {
+        styleApplierDouble = nil
+        super.tearDown()
+    }
+
+
+    func testProcess_EditedSingleLine_ResetsAttributesForWholeLine() {
+
+        let string = "single"
+        let editedRange = NSRange(location: 0, length: 0)
+
+        let result = MarklightTextProcessor().processEditing(styleApplier: styleApplierDouble, string: string, editedRange: editedRange)
+
+        let expectedAffectedRange = NSRange(location: 0, length: 6)
+        XCTAssertNotNil(styleApplierDouble.didResetMarklightTextAttributes)
+        if let values = styleApplierDouble.didResetMarklightTextAttributes {
+            XCTAssertEqual(values.range, expectedAffectedRange)
+        }
+
+        XCTAssertEqual(result.editedRange, editedRange)
+        XCTAssertEqual(result.affectedRange, expectedAffectedRange)
+    }
+
+
+    func testProcess_EditedFirstLine_ResetsAttributesForFirstAndSecondLine() {
+
+        let string = "1\n2\n3\n"
+        let editedRange = NSRange(location: 0, length: 0)
+
+        let result = MarklightTextProcessor().processEditing(styleApplier: styleApplierDouble, string: string, editedRange: editedRange)
+
+        let expectedAffectedRange = NSRange(location: 0, length: 4)
+        XCTAssertNotNil(styleApplierDouble.didResetMarklightTextAttributes)
+        if let values = styleApplierDouble.didResetMarklightTextAttributes {
+            XCTAssertEqual(values.range, expectedAffectedRange)
+        }
+
+        XCTAssertEqual(result.editedRange, editedRange)
+        XCTAssertEqual(result.affectedRange, expectedAffectedRange)
+    }
+
+    func testProcess_EditedAtMiddleOfMiddleLine_ResetsAttributesForSurroundingLines() {
+
+        let string = "1\n2\n3333\n4\n5\n"
+        //               ^^ ^^^^^ ^^
+        let editedRange = NSRange(location: 6, length: 0)
+
+        let result = MarklightTextProcessor().processEditing(styleApplier: styleApplierDouble, string: string, editedRange: editedRange)
+
+        let expectedAffectedRange = NSRange(location: 2, length: 9)
+        XCTAssertNotNil(styleApplierDouble.didResetMarklightTextAttributes)
+        if let values = styleApplierDouble.didResetMarklightTextAttributes {
+            XCTAssertEqual(values.range, expectedAffectedRange)
+        }
+
+        XCTAssertEqual(result.editedRange, editedRange)
+        XCTAssertEqual(result.affectedRange, expectedAffectedRange)
+    }
+}

--- a/Sample/Marklight Sample macOS/ViewController.swift
+++ b/Sample/Marklight Sample macOS/ViewController.swift
@@ -17,25 +17,21 @@ class ViewController: NSViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        textStorage.codeColor = NSColor.orange
-        textStorage.quoteColor = NSColor.darkGray
-        textStorage.syntaxColor = NSColor.blue
-        textStorage.codeFontName = "Courier"
-        textStorage.textSize = 18.0
-        textStorage.hideSyntax = true
+        textStorage.marklightTextProcessor.codeColor = NSColor.orange
+        textStorage.marklightTextProcessor.quoteColor = NSColor.darkGray
+        textStorage.marklightTextProcessor.syntaxColor = NSColor.blue
+        textStorage.marklightTextProcessor.codeFontName = "Courier"
+        textStorage.marklightTextProcessor.textSize = 18.0
+        textStorage.marklightTextProcessor.hideSyntax = true
 
         textView.layoutManager?.replaceTextStorage(textStorage)
 
         textView.textContainerInset = NSSize(width: 10, height: 8)
 
-        if let samplePath = Bundle.main.path(forResource: "Sample", ofType:  "md"){
-            do {
-                let string = try String(contentsOfFile: samplePath)
-                let attributedString = NSAttributedString(string: string)
-                textStorage.append(attributedString)
-            } catch _ {
-                print("Cannot read Sample.md file")
-            }
+        if let samplePath = Bundle.main.path(forResource: "Sample", ofType: "md"),
+            let string = try? String(contentsOfFile: samplePath) {
+            let attributedString = NSAttributedString(string: string)
+            textStorage.append(attributedString)
         }
     }
 }

--- a/Sample/Marklight Sample/ViewController.swift
+++ b/Sample/Marklight Sample/ViewController.swift
@@ -24,12 +24,12 @@ class ViewController: UIViewController, UITextViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        textStorage.codeColor = UIColor.orange
-        textStorage.quoteColor = UIColor.darkGray
-        textStorage.syntaxColor = UIColor.blue
-        textStorage.codeFontName = "Courier"
-        textStorage.fontTextStyle = UIFontTextStyle.subheadline.rawValue
-        textStorage.hideSyntax = true
+        textStorage.marklightTextProcessor.codeColor = UIColor.orange
+        textStorage.marklightTextProcessor.quoteColor = UIColor.darkGray
+        textStorage.marklightTextProcessor.syntaxColor = UIColor.blue
+        textStorage.marklightTextProcessor.codeFontName = "Courier"
+        textStorage.marklightTextProcessor.fontTextStyle = UIFontTextStyle.subheadline.rawValue
+        textStorage.marklightTextProcessor.hideSyntax = true
         
         let layoutManager = NSLayoutManager()
         

--- a/Sample/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Sample/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,30 +7,34 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		026C3472A6020B414F0F300DB8E6C114 /* MarklightStyleApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECB804DB566D0485570316C3CE1553D /* MarklightStyleApplier.swift */; };
 		1688361F6523285811FCA642E4E536CC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */; };
+		259635D8BC6BA7B19526709AB0CA2F52 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612C089ED112A9DEF21BD6BB41B144BD /* Array+appending.swift */; };
+		267412CA961994CBED6C797096FE7BCA /* MarklightTextProcessingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025D286C610121054F22D01CB71443AA /* MarklightTextProcessingResult.swift */; };
 		2E612F9ADF28C1FA478362A5D4581F2F /* Pods-Marklight-Marklight Sample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AA5F181E888ACFDFF647DBBDF734C7 /* Pods-Marklight-Marklight Sample-dummy.m */; };
-		3664F2379791BA3FB5233ED22A6933AE /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */; };
-		370C9C177882F3250C2AE059ED756C4E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */; };
+		40D9E0B46A07D8C5ABB28A55A40FDDF4 /* MarklightStyleApplier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECB804DB566D0485570316C3CE1553D /* MarklightStyleApplier.swift */; };
 		42EF4612EDE4034EE0D12AF27E80034A /* Pods-Marklight-Marklight Sample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 504AFCB6CDCED06DFA7CBCCE54EB4B10 /* Pods-Marklight-Marklight Sample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		44BAD6158348D6FE49EEE205D8649192 /* Pods-Marklight-Marklight Sample macOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E6CB78FFFA83229A53A147A62F96F3 /* Pods-Marklight-Marklight Sample macOS-dummy.m */; };
-		4781B9E1469B546300D45C7BA39578DB /* Marklight-OSX-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B77DBBE59479C061249CF795CB03F80F /* Marklight-OSX-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		519848CA483F894A92BB87ADBA874549 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */; };
-		51CC562DEA3236D4FB6A41DC9C81D65F /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */; };
-		6E5797D9EEF3E318F65356927A54F236 /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */; };
-		7767F4899B96DF51A0A068810535C180 /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */; };
-		79BA9814D2CA62BD62A70B8C0FF43731 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */; };
+		52291E3A26A9E122BAE06406302449A7 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612C089ED112A9DEF21BD6BB41B144BD /* Array+appending.swift */; };
+		52B304FE8D5B9EDC6323DF8FA55D0E89 /* Marklight-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = E821D274F41467ADF66744CE7390162E /* Marklight-iOS-dummy.m */; };
+		5B9A9FF595A8200B365C880D31A0EC5A /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4492D55E7152A316C48B76C4C80A82 /* NSString+paragraphRangeAt.swift */; };
+		658BFF0D0F4BBCCE895E317E7E4275D4 /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7636E3A421D23C1C341A5C59FC6BBF6E /* MarklightTextStorage.swift */; };
+		6B7DE6049CC945610E7A836FBE4C2D1C /* Marklight-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 01368CDA942FFAFAD433410F9C909A96 /* Marklight-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6EAA0BDAE91C8489B57EB3C085A3239F /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7636E3A421D23C1C341A5C59FC6BBF6E /* MarklightTextStorage.swift */; };
+		70041FAE75DF9F80F40926D78E26149F /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4492D55E7152A316C48B76C4C80A82 /* NSString+paragraphRangeAt.swift */; };
+		705C225926C2CD945D3F64D51041C0E7 /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F33EB75C9A7C07FA165E57841F5FED /* Marklight.swift */; };
+		780FBF28BEE6C6C229839CEED677D6A8 /* Marklight-OSX-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 2289068C7DA2431476D71F9977278873 /* Marklight-OSX-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7B562DF5352182069A7259ECA459C124 /* Marklight-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 57374C6969FA22CE7F0F4998FEA95EC5 /* Marklight-OSX-dummy.m */; };
 		8599BADDD54D8331FA293C0A63D5364D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */; };
-		8F9D7363963B17C61020C76B18516E03 /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */; };
-		9CA5606C730E11C270D4EF63C450D33E /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */; };
-		ADB27804691505904B89614817DBA425 /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */; };
-		B81E57417115ED06E2D22FC483007975 /* Marklight-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 11C7A870C264B19BC3BA5C46C79B024D /* Marklight-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C4255F2982780AEBC9FDADE730BDFC0E /* Marklight-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C0BA33EDBB3DDD87C304D8DA51428121 /* Marklight-OSX-dummy.m */; };
-		CDA6ED0FC38669F17F29450128284258 /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */; };
-		DCA7FDAB52F45CA422BC34BCE98C283A /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */; };
-		EA3143B795F02EEB17560B9647164174 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */; };
+		91CDF1673F823DC597FDAB979026620B /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98537DC6B8B111FE46CBD4F2DD6CBF9E /* MarklightTextProcessor.swift */; };
+		9967E21112BF4CC4ACE3CBA4AAB2E189 /* MarklightTextProcessingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025D286C610121054F22D01CB71443AA /* MarklightTextProcessingResult.swift */; };
+		9E0BE6C1C2A122226B1A008007B92EA2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */; };
+		A25E1703F865DFEC113D2F93A3925D5D /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98537DC6B8B111FE46CBD4F2DD6CBF9E /* MarklightTextProcessor.swift */; };
+		AEBDB28070E5F0B2A883CFE5306E1278 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */; };
+		AF28C8F226ED26BDCFAB44B14AD0557A /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F33EB75C9A7C07FA165E57841F5FED /* Marklight.swift */; };
+		BBE7C309FB560C16D5F2501F5C26FE5D /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD965A3BEF3FCE1369B3ACD5AD1377A /* UniversalTypes.swift */; };
+		DE908BC125EA9806998804708FE74C0C /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD965A3BEF3FCE1369B3ACD5AD1377A /* UniversalTypes.swift */; };
 		EB8BFD7AC77D589580982C6E57375A1F /* Pods-Marklight-Marklight Sample macOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D997AD92D29379A9564227402B1DB03 /* Pods-Marklight-Marklight Sample macOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		ECAC67C401D85631B0EA322C3BC3257A /* Marklight-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC34D49FDB9FFCDE3064ABFC924379F /* Marklight-iOS-dummy.m */; };
-		F83F9479DF7B128B6775740B14BDDEC0 /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,67 +42,77 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D4A2D237D9ABC1BC6AED7D1ED13D58B6;
+			remoteGlobalIDString = 9DD8278A55D282101A5721361FA9110B;
 			remoteInfo = "Marklight-OSX";
 		};
 		EDFF6DDEFC27C6A28120D9AF3896B194 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D78D99AFCE85B7A0335DB0F35509DA46;
+			remoteGlobalIDString = 32E450128C237154C5EFCC9BB53F3C9D;
 			remoteInfo = "Marklight-iOS";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		01368CDA942FFAFAD433410F9C909A96 /* Marklight-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-umbrella.h"; path = "../Marklight-iOS/Marklight-iOS-umbrella.h"; sourceTree = "<group>"; };
+		025D286C610121054F22D01CB71443AA /* MarklightTextProcessingResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessingResult.swift; sourceTree = "<group>"; };
+		06F2B320C1E6E7DE4D825207B43EECC2 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Marklight-iOS/Info.plist"; sourceTree = "<group>"; };
 		09226AE663C2BBB2FBAF315C196479F7 /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Marklight.framework; path = "Marklight-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		11C7A870C264B19BC3BA5C46C79B024D /* Marklight-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-umbrella.h"; path = "../Marklight-iOS/Marklight-iOS-umbrella.h"; sourceTree = "<group>"; };
-		176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSString+paragraphRangeAt.swift"; sourceTree = "<group>"; };
+		12587CB0789C52608C2AD324E1A95899 /* Marklight-OSX.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Marklight-OSX.modulemap"; sourceTree = "<group>"; };
 		1954BB0D4690843F084A66BA41B7CB09 /* Pods-Marklight-Marklight Sample macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample macOS.debug.xcconfig"; sourceTree = "<group>"; };
-		30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessor.swift; sourceTree = "<group>"; };
-		3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Marklight.swift; sourceTree = "<group>"; };
+		1BB4C84DBDF1B3B4CAC1ED630537CFA3 /* Marklight-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-prefix.pch"; path = "../Marklight-iOS/Marklight-iOS-prefix.pch"; sourceTree = "<group>"; };
+		1E6CD261EF172768015017065ED605E6 /* Marklight-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "Marklight-iOS.modulemap"; path = "../Marklight-iOS/Marklight-iOS.modulemap"; sourceTree = "<group>"; };
+		1F68406BE5E749A41BBAF823AFA5A281 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2289068C7DA2431476D71F9977278873 /* Marklight-OSX-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-umbrella.h"; sourceTree = "<group>"; };
+		2E4492D55E7152A316C48B76C4C80A82 /* NSString+paragraphRangeAt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSString+paragraphRangeAt.swift"; sourceTree = "<group>"; };
 		4B5BAF31CDC2E5C8D6FB1C4E26D87313 /* Pods_Marklight_Marklight_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Marklight_Marklight_Sample.framework; path = "Pods-Marklight-Marklight Sample.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		504AFCB6CDCED06DFA7CBCCE54EB4B10 /* Pods-Marklight-Marklight Sample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Marklight-Marklight Sample-umbrella.h"; sourceTree = "<group>"; };
 		56F6F4CECF6458464F20294A63B168F4 /* Pods-Marklight-Marklight Sample macOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample macOS-frameworks.sh"; sourceTree = "<group>"; };
+		57374C6969FA22CE7F0F4998FEA95EC5 /* Marklight-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Marklight-OSX-dummy.m"; sourceTree = "<group>"; };
 		5BEC194900724FA39134E150F2565D3B /* Pods-Marklight-Marklight Sample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Marklight-Marklight Sample-acknowledgements.plist"; sourceTree = "<group>"; };
 		5DE6924255815EFAE93E0BE6DEC59070 /* Pods-Marklight-Marklight Sample macOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-Marklight-Marklight Sample macOS.modulemap"; sourceTree = "<group>"; };
-		5E68ECA9B9BE2D491DA7DC56FDF362BF /* Marklight-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "Marklight-iOS.modulemap"; path = "../Marklight-iOS/Marklight-iOS.modulemap"; sourceTree = "<group>"; };
-		60F2DF4C231091D14C81A4DE66A5E143 /* Marklight-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-prefix.pch"; path = "../Marklight-iOS/Marklight-iOS-prefix.pch"; sourceTree = "<group>"; };
+		612C089ED112A9DEF21BD6BB41B144BD /* Array+appending.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+appending.swift"; sourceTree = "<group>"; };
+		6BD965A3BEF3FCE1369B3ACD5AD1377A /* UniversalTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UniversalTypes.swift; sourceTree = "<group>"; };
 		71E6CB78FFFA83229A53A147A62F96F3 /* Pods-Marklight-Marklight Sample macOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Marklight-Marklight Sample macOS-dummy.m"; sourceTree = "<group>"; };
-		79A969CD7673F309545866367D462B9D /* Marklight-OSX.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Marklight-OSX.modulemap"; sourceTree = "<group>"; };
-		7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Marklight-iOS.xcconfig"; path = "../Marklight-iOS/Marklight-iOS.xcconfig"; sourceTree = "<group>"; };
+		75E06F08CB2620BC5A0B72057564088E /* Marklight-OSX.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Marklight-OSX.xcconfig"; sourceTree = "<group>"; };
+		7636E3A421D23C1C341A5C59FC6BBF6E /* MarklightTextStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextStorage.swift; sourceTree = "<group>"; };
+		8332EC687DDDE711676AF70E7D0D315A /* Marklight-OSX-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-prefix.pch"; sourceTree = "<group>"; };
 		843C32C9C475C8EC0FB7B7C033B8DEE9 /* Pods-Marklight-Marklight Sample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-Marklight-Marklight Sample.modulemap"; sourceTree = "<group>"; };
-		9000EF24CB70E6F25A25DAF6B887E7FF /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Marklight-iOS/Info.plist"; sourceTree = "<group>"; };
 		92BC6DE58210B38C700FD11D6A87D0F3 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UniversalTypes.swift; sourceTree = "<group>"; };
+		98537DC6B8B111FE46CBD4F2DD6CBF9E /* MarklightTextProcessor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessor.swift; sourceTree = "<group>"; };
+		98F33EB75C9A7C07FA165E57841F5FED /* Marklight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Marklight.swift; sourceTree = "<group>"; };
 		9A0C55E39FDA6434BFBEFA5297FF5F28 /* Pods-Marklight-Marklight Sample macOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Marklight-Marklight Sample macOS-acknowledgements.markdown"; sourceTree = "<group>"; };
 		9D997AD92D29379A9564227402B1DB03 /* Pods-Marklight-Marklight Sample macOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Marklight-Marklight Sample macOS-umbrella.h"; sourceTree = "<group>"; };
 		A183DAE50D3D1375CC1E5940AAD8669B /* Pods-Marklight-Marklight Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample.debug.xcconfig"; sourceTree = "<group>"; };
 		A9138CF4A09889A9CA257732DF184F40 /* Pods-Marklight-Marklight Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample.release.xcconfig"; sourceTree = "<group>"; };
-		B0B30CC1CD4D8F901668929DE510E5EF /* Marklight-OSX-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-prefix.pch"; sourceTree = "<group>"; };
+		B0C86199758318E8850BE6583AFCEA52 /* Marklight-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Marklight-iOS.xcconfig"; path = "../Marklight-iOS/Marklight-iOS.xcconfig"; sourceTree = "<group>"; };
 		B2AA5F181E888ACFDFF647DBBDF734C7 /* Pods-Marklight-Marklight Sample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Marklight-Marklight Sample-dummy.m"; sourceTree = "<group>"; };
-		B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextStorage.swift; sourceTree = "<group>"; };
-		B77DBBE59479C061249CF795CB03F80F /* Marklight-OSX-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-umbrella.h"; sourceTree = "<group>"; };
-		B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Marklight-OSX.xcconfig"; sourceTree = "<group>"; };
 		BAF7151CA41F63FD764D705A4A21486D /* Pods-Marklight-Marklight Sample macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample macOS.release.xcconfig"; sourceTree = "<group>"; };
-		C0BA33EDBB3DDD87C304D8DA51428121 /* Marklight-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Marklight-OSX-dummy.m"; sourceTree = "<group>"; };
 		CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
-		CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+appending.swift"; sourceTree = "<group>"; };
 		D49625C52D5D30481B2951F7332F49B3 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9699F78DFC2F89B90E2B41EFECFCF00 /* Pods-Marklight-Marklight Sample-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample-frameworks.sh"; sourceTree = "<group>"; };
 		DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		DBC34D49FDB9FFCDE3064ABFC924379F /* Marklight-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Marklight-iOS-dummy.m"; path = "../Marklight-iOS/Marklight-iOS-dummy.m"; sourceTree = "<group>"; };
 		E05DF1B938576A3A34C7C1D2D6460105 /* Pods-Marklight-Marklight Sample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Marklight-Marklight Sample-acknowledgements.markdown"; sourceTree = "<group>"; };
 		E3992CF302A62CD93304B4800D70CB20 /* Pods-Marklight-Marklight Sample macOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample macOS-resources.sh"; sourceTree = "<group>"; };
 		E64FF4B4B61227C565A28D9F1A796579 /* Pods_Marklight_Marklight_Sample_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Marklight_Marklight_Sample_macOS.framework; path = "Pods-Marklight-Marklight Sample macOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E821D274F41467ADF66744CE7390162E /* Marklight-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Marklight-iOS-dummy.m"; path = "../Marklight-iOS/Marklight-iOS-dummy.m"; sourceTree = "<group>"; };
 		E8BD4078E9B4674831BB5E515FD95999 /* Pods-Marklight-Marklight Sample-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample-resources.sh"; sourceTree = "<group>"; };
 		E9432A6655CE7E92A6099DAE20BF835D /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Marklight.framework; path = "Marklight-OSX.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EC590753D13E25C74ACE4AE3BB2AD4E1 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FAC8140593AF379498930206868F9871 /* Pods-Marklight-Marklight Sample macOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Marklight-Marklight Sample macOS-acknowledgements.plist"; sourceTree = "<group>"; };
+		FECB804DB566D0485570316C3CE1553D /* MarklightStyleApplier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightStyleApplier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1761C1A30095FCB61CB762979BD2EF1F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9E0BE6C1C2A122226B1A008007B92EA2 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		838C3BCBCA9B8A3E1453B6A2CF5E9821 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -115,19 +129,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9AAC9599A461936A2D144E75AA408C44 /* Frameworks */ = {
+		B776F3853910DA676BE90B747EAE1E81 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				370C9C177882F3250C2AE059ED756C4E /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DEE2D98C1FD1DA05029E0A771F9E1252 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				EA3143B795F02EEB17560B9647164174 /* Foundation.framework in Frameworks */,
+				AEBDB28070E5F0B2A883CFE5306E1278 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,6 +158,42 @@
 			path = "Target Support Files/Pods-Marklight-Marklight Sample macOS";
 			sourceTree = "<group>";
 		};
+		099837689FF1C18269EFA7862B6E017D /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				1F68406BE5E749A41BBAF823AFA5A281 /* Info.plist */,
+				06F2B320C1E6E7DE4D825207B43EECC2 /* Info.plist */,
+				1E6CD261EF172768015017065ED605E6 /* Marklight-iOS.modulemap */,
+				B0C86199758318E8850BE6583AFCEA52 /* Marklight-iOS.xcconfig */,
+				E821D274F41467ADF66744CE7390162E /* Marklight-iOS-dummy.m */,
+				1BB4C84DBDF1B3B4CAC1ED630537CFA3 /* Marklight-iOS-prefix.pch */,
+				01368CDA942FFAFAD433410F9C909A96 /* Marklight-iOS-umbrella.h */,
+				12587CB0789C52608C2AD324E1A95899 /* Marklight-OSX.modulemap */,
+				75E06F08CB2620BC5A0B72057564088E /* Marklight-OSX.xcconfig */,
+				57374C6969FA22CE7F0F4998FEA95EC5 /* Marklight-OSX-dummy.m */,
+				8332EC687DDDE711676AF70E7D0D315A /* Marklight-OSX-prefix.pch */,
+				2289068C7DA2431476D71F9977278873 /* Marklight-OSX-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Sample/Pods/Target Support Files/Marklight-OSX";
+			sourceTree = "<group>";
+		};
+		2D2E1108801652179F969BF1F480C08E /* Marklight */ = {
+			isa = PBXGroup;
+			children = (
+				612C089ED112A9DEF21BD6BB41B144BD /* Array+appending.swift */,
+				98F33EB75C9A7C07FA165E57841F5FED /* Marklight.swift */,
+				FECB804DB566D0485570316C3CE1553D /* MarklightStyleApplier.swift */,
+				025D286C610121054F22D01CB71443AA /* MarklightTextProcessingResult.swift */,
+				98537DC6B8B111FE46CBD4F2DD6CBF9E /* MarklightTextProcessor.swift */,
+				7636E3A421D23C1C341A5C59FC6BBF6E /* MarklightTextStorage.swift */,
+				2E4492D55E7152A316C48B76C4C80A82 /* NSString+paragraphRangeAt.swift */,
+				6BD965A3BEF3FCE1369B3ACD5AD1377A /* UniversalTypes.swift */,
+			);
+			name = Marklight;
+			path = Marklight;
+			sourceTree = "<group>";
+		};
 		2EDFAB15A7E74F864EB353FCB5A57006 /* OS X */ = {
 			isa = PBXGroup;
 			children = (
@@ -172,7 +214,7 @@
 		3CE0CAFB364A3E73297AABDAF874D71B /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E70532A2910B368ACE48BAB31F64913D /* Marklight */,
+				8CF5FF59B7C2B4C91B18975115F7743E /* Marklight */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
@@ -207,6 +249,16 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
+		8CF5FF59B7C2B4C91B18975115F7743E /* Marklight */ = {
+			isa = PBXGroup;
+			children = (
+				2D2E1108801652179F969BF1F480C08E /* Marklight */,
+				099837689FF1C18269EFA7862B6E017D /* Support Files */,
+			);
+			name = Marklight;
+			path = ../..;
+			sourceTree = "<group>";
+		};
 		8FB24DE05C04F8748508A9DCEAD9313F /* Pods-Marklight-Marklight Sample */ = {
 			isa = PBXGroup;
 			children = (
@@ -225,20 +277,6 @@
 			path = "Target Support Files/Pods-Marklight-Marklight Sample";
 			sourceTree = "<group>";
 		};
-		9A5C4845C142DE31B9D8582ACF6DA257 /* Marklight */ = {
-			isa = PBXGroup;
-			children = (
-				CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */,
-				3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */,
-				30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */,
-				B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */,
-				176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */,
-				953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */,
-			);
-			name = Marklight;
-			path = Marklight;
-			sourceTree = "<group>";
-		};
 		D9264F83C4D02B328DC17E03FD692462 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -248,44 +286,14 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		E70532A2910B368ACE48BAB31F64913D /* Marklight */ = {
-			isa = PBXGroup;
-			children = (
-				9A5C4845C142DE31B9D8582ACF6DA257 /* Marklight */,
-				FA36D0A18319FE94CA6A259977B6F78A /* Support Files */,
-			);
-			name = Marklight;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		FA36D0A18319FE94CA6A259977B6F78A /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				EC590753D13E25C74ACE4AE3BB2AD4E1 /* Info.plist */,
-				9000EF24CB70E6F25A25DAF6B887E7FF /* Info.plist */,
-				5E68ECA9B9BE2D491DA7DC56FDF362BF /* Marklight-iOS.modulemap */,
-				7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */,
-				DBC34D49FDB9FFCDE3064ABFC924379F /* Marklight-iOS-dummy.m */,
-				60F2DF4C231091D14C81A4DE66A5E143 /* Marklight-iOS-prefix.pch */,
-				11C7A870C264B19BC3BA5C46C79B024D /* Marklight-iOS-umbrella.h */,
-				79A969CD7673F309545866367D462B9D /* Marklight-OSX.modulemap */,
-				B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */,
-				C0BA33EDBB3DDD87C304D8DA51428121 /* Marklight-OSX-dummy.m */,
-				B0B30CC1CD4D8F901668929DE510E5EF /* Marklight-OSX-prefix.pch */,
-				B77DBBE59479C061249CF795CB03F80F /* Marklight-OSX-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "Sample/Pods/Target Support Files/Marklight-OSX";
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		502C507F87AF742C55CFB0764479B205 /* Headers */ = {
+		69F52DDF95880F98832CABE0EE6EA169 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4781B9E1469B546300D45C7BA39578DB /* Marklight-OSX-umbrella.h in Headers */,
+				6B7DE6049CC945610E7A836FBE4C2D1C /* Marklight-iOS-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,14 +305,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D43950DFCF3CF6F61F0BBEAADEAA0F91 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B81E57417115ED06E2D22FC483007975 /* Marklight-iOS-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DFAE9A002B8DF1921DFC4808F2CFE901 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -313,9 +313,34 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EF07203A9293A1DF4B8AAFC53ADE0E33 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				780FBF28BEE6C6C229839CEED677D6A8 /* Marklight-OSX-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		32E450128C237154C5EFCC9BB53F3C9D /* Marklight-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BA7FFC1A624906CABF98106C1D655A73 /* Build configuration list for PBXNativeTarget "Marklight-iOS" */;
+			buildPhases = (
+				52DFAE4A9C6CB37320FA0C0B406C5FB7 /* Sources */,
+				B776F3853910DA676BE90B747EAE1E81 /* Frameworks */,
+				69F52DDF95880F98832CABE0EE6EA169 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Marklight-iOS";
+			productName = "Marklight-iOS";
+			productReference = 09226AE663C2BBB2FBAF315C196479F7 /* Marklight.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		697E675E9FEA55D981D23AC9EC78195F /* Pods-Marklight-Marklight Sample */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13BFD20C5B172C896675565104CE6EC4 /* Build configuration list for PBXNativeTarget "Pods-Marklight-Marklight Sample" */;
@@ -352,13 +377,13 @@
 			productReference = E64FF4B4B61227C565A28D9F1A796579 /* Pods_Marklight_Marklight_Sample_macOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		D4A2D237D9ABC1BC6AED7D1ED13D58B6 /* Marklight-OSX */ = {
+		9DD8278A55D282101A5721361FA9110B /* Marklight-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = ABE5CD311792B8D7476EF9FFB5ED2CED /* Build configuration list for PBXNativeTarget "Marklight-OSX" */;
+			buildConfigurationList = 30D7EA1F09A475D6998E470BBB722EEA /* Build configuration list for PBXNativeTarget "Marklight-OSX" */;
 			buildPhases = (
-				9A89A687ACCDDFB04B24CA0C0DAD669C /* Sources */,
-				9AAC9599A461936A2D144E75AA408C44 /* Frameworks */,
-				502C507F87AF742C55CFB0764479B205 /* Headers */,
+				25CA4B59B791E8D5698140A4A8319F0C /* Sources */,
+				1761C1A30095FCB61CB762979BD2EF1F /* Frameworks */,
+				EF07203A9293A1DF4B8AAFC53ADE0E33 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -367,23 +392,6 @@
 			name = "Marklight-OSX";
 			productName = "Marklight-OSX";
 			productReference = E9432A6655CE7E92A6099DAE20BF835D /* Marklight.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		D78D99AFCE85B7A0335DB0F35509DA46 /* Marklight-iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 1B849E3796E0D2A8F36AD45B17FFBA8D /* Build configuration list for PBXNativeTarget "Marklight-iOS" */;
-			buildPhases = (
-				DA26E7CC9708A1F14EC14496D19E4B90 /* Sources */,
-				DEE2D98C1FD1DA05029E0A771F9E1252 /* Frameworks */,
-				D43950DFCF3CF6F61F0BBEAADEAA0F91 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Marklight-iOS";
-			productName = "Marklight-iOS";
-			productReference = 09226AE663C2BBB2FBAF315C196479F7 /* Marklight.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -407,8 +415,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				D78D99AFCE85B7A0335DB0F35509DA46 /* Marklight-iOS */,
-				D4A2D237D9ABC1BC6AED7D1ED13D58B6 /* Marklight-OSX */,
+				32E450128C237154C5EFCC9BB53F3C9D /* Marklight-iOS */,
+				9DD8278A55D282101A5721361FA9110B /* Marklight-OSX */,
 				697E675E9FEA55D981D23AC9EC78195F /* Pods-Marklight-Marklight Sample */,
 				8EB7F7E7CF8D53F0D9C2D78CB060474D /* Pods-Marklight-Marklight Sample macOS */,
 			);
@@ -416,11 +424,43 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
+		25CA4B59B791E8D5698140A4A8319F0C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				52291E3A26A9E122BAE06406302449A7 /* Array+appending.swift in Sources */,
+				7B562DF5352182069A7259ECA459C124 /* Marklight-OSX-dummy.m in Sources */,
+				AF28C8F226ED26BDCFAB44B14AD0557A /* Marklight.swift in Sources */,
+				40D9E0B46A07D8C5ABB28A55A40FDDF4 /* MarklightStyleApplier.swift in Sources */,
+				9967E21112BF4CC4ACE3CBA4AAB2E189 /* MarklightTextProcessingResult.swift in Sources */,
+				91CDF1673F823DC597FDAB979026620B /* MarklightTextProcessor.swift in Sources */,
+				6EAA0BDAE91C8489B57EB3C085A3239F /* MarklightTextStorage.swift in Sources */,
+				5B9A9FF595A8200B365C880D31A0EC5A /* NSString+paragraphRangeAt.swift in Sources */,
+				DE908BC125EA9806998804708FE74C0C /* UniversalTypes.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		44018E33279B16FF4BBE3D0477B39675 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				2E612F9ADF28C1FA478362A5D4581F2F /* Pods-Marklight-Marklight Sample-dummy.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		52DFAE4A9C6CB37320FA0C0B406C5FB7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				259635D8BC6BA7B19526709AB0CA2F52 /* Array+appending.swift in Sources */,
+				52B304FE8D5B9EDC6323DF8FA55D0E89 /* Marklight-iOS-dummy.m in Sources */,
+				705C225926C2CD945D3F64D51041C0E7 /* Marklight.swift in Sources */,
+				026C3472A6020B414F0F300DB8E6C114 /* MarklightStyleApplier.swift in Sources */,
+				267412CA961994CBED6C797096FE7BCA /* MarklightTextProcessingResult.swift in Sources */,
+				A25E1703F865DFEC113D2F93A3925D5D /* MarklightTextProcessor.swift in Sources */,
+				658BFF0D0F4BBCCE895E317E7E4275D4 /* MarklightTextStorage.swift in Sources */,
+				70041FAE75DF9F80F40926D78E26149F /* NSString+paragraphRangeAt.swift in Sources */,
+				BBE7C309FB560C16D5F2501F5C26FE5D /* UniversalTypes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -432,123 +472,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9A89A687ACCDDFB04B24CA0C0DAD669C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				519848CA483F894A92BB87ADBA874549 /* Array+appending.swift in Sources */,
-				C4255F2982780AEBC9FDADE730BDFC0E /* Marklight-OSX-dummy.m in Sources */,
-				7767F4899B96DF51A0A068810535C180 /* Marklight.swift in Sources */,
-				6E5797D9EEF3E318F65356927A54F236 /* MarklightTextProcessor.swift in Sources */,
-				51CC562DEA3236D4FB6A41DC9C81D65F /* MarklightTextStorage.swift in Sources */,
-				8F9D7363963B17C61020C76B18516E03 /* NSString+paragraphRangeAt.swift in Sources */,
-				DCA7FDAB52F45CA422BC34BCE98C283A /* UniversalTypes.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DA26E7CC9708A1F14EC14496D19E4B90 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				79BA9814D2CA62BD62A70B8C0FF43731 /* Array+appending.swift in Sources */,
-				ECAC67C401D85631B0EA322C3BC3257A /* Marklight-iOS-dummy.m in Sources */,
-				F83F9479DF7B128B6775740B14BDDEC0 /* Marklight.swift in Sources */,
-				9CA5606C730E11C270D4EF63C450D33E /* MarklightTextProcessor.swift in Sources */,
-				ADB27804691505904B89614817DBA425 /* MarklightTextStorage.swift in Sources */,
-				3664F2379791BA3FB5233ED22A6933AE /* NSString+paragraphRangeAt.swift in Sources */,
-				CDA6ED0FC38669F17F29450128284258 /* UniversalTypes.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		4EDD112EABC9E602DDC18E91B13AC62B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Marklight-iOS";
-			target = D78D99AFCE85B7A0335DB0F35509DA46 /* Marklight-iOS */;
+			target = 32E450128C237154C5EFCC9BB53F3C9D /* Marklight-iOS */;
 			targetProxy = EDFF6DDEFC27C6A28120D9AF3896B194 /* PBXContainerItemProxy */;
 		};
 		71B0F246F2104A714462AF51C4C585FC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Marklight-OSX";
-			target = D4A2D237D9ABC1BC6AED7D1ED13D58B6 /* Marklight-OSX */;
+			target = 9DD8278A55D282101A5721361FA9110B /* Marklight-OSX */;
 			targetProxy = 096959BF7B4A353DED187472DBE6949C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		05F96560E7899DDA9EE91F2C9ACB04AC /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Marklight;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		08B884FB44472DC77B6FF0775B85F821 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Marklight;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		1EA6D4F64AEA6FC566C540F6A24C0816 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BAF7151CA41F63FD764D705A4A21486D /* Pods-Marklight-Marklight Sample macOS.release.xcconfig */;
@@ -623,75 +564,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		33B838B889FFAEED3E24326B3C9B27E0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Marklight;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		55018D6A7A7334B2F68208FFB2E786DE /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Marklight;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -773,6 +645,111 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		83DBD2D571B8AD1C8499CD769ED46899 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B0C86199758318E8850BE6583AFCEA52 /* Marklight-iOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		8ADBC99F9388F44F01AA91869EC4D8B1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 75E06F08CB2620BC5A0B72057564088E /* Marklight-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		96F2C06312581670E32D90AFE88BF438 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B0C86199758318E8850BE6583AFCEA52 /* Marklight-iOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		A8B5B50A6D07282143D0ED5E229EBFB0 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -868,6 +845,41 @@
 			};
 			name = Release;
 		};
+		F40CCA8C14AB3F9A26DC8D36FB515A9B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 75E06F08CB2620BC5A0B72057564088E /* Marklight-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -876,15 +888,6 @@
 			buildConfigurations = (
 				5EDFEC883820B96EDB4FED824DDCDB9F /* Debug */,
 				6A4CEC746BC55FB58DE9773FEA8BFD09 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		1B849E3796E0D2A8F36AD45B17FFBA8D /* Build configuration list for PBXNativeTarget "Marklight-iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				55018D6A7A7334B2F68208FFB2E786DE /* Debug */,
-				33B838B889FFAEED3E24326B3C9B27E0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -898,6 +901,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		30D7EA1F09A475D6998E470BBB722EEA /* Build configuration list for PBXNativeTarget "Marklight-OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8ADBC99F9388F44F01AA91869EC4D8B1 /* Debug */,
+				F40CCA8C14AB3F9A26DC8D36FB515A9B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7B557BD194741EC1237ECC77A6119938 /* Build configuration list for PBXNativeTarget "Pods-Marklight-Marklight Sample macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -907,11 +919,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		ABE5CD311792B8D7476EF9FFB5ED2CED /* Build configuration list for PBXNativeTarget "Marklight-OSX" */ = {
+		BA7FFC1A624906CABF98106C1D655A73 /* Build configuration list for PBXNativeTarget "Marklight-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				08B884FB44472DC77B6FF0775B85F821 /* Debug */,
-				05F96560E7899DDA9EE91F2C9ACB04AC /* Release */,
+				96F2C06312581670E32D90AFE88BF438 /* Debug */,
+				83DBD2D571B8AD1C8499CD769ED46899 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Sample/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Sample/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,24 +7,30 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		12814CDA839CD44B3CB35FE80F847638 /* Marklight-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 89519AAD333DD1080C1BA48113AE4142 /* Marklight-iOS-dummy.m */; };
 		1688361F6523285811FCA642E4E536CC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */; };
-		1EF1BCD06CE275FF3B3195FFC762E51A /* Marklight-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5F78B93D1D21F6D0935B7E5E2FC65B87 /* Marklight-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		24BCF0333FD6E6C42D35AF9D8030DF3E /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = E048FEFBEA05C67CEFB5D8F1278B20F1 /* Marklight.swift */; };
 		2E612F9ADF28C1FA478362A5D4581F2F /* Pods-Marklight-Marklight Sample-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AA5F181E888ACFDFF647DBBDF734C7 /* Pods-Marklight-Marklight Sample-dummy.m */; };
-		3E2144BB6CA49BE0729EA21AD9C054D2 /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A770FEC64CC51A0EC7FB727C96E4E4D /* MarklightTextStorage.swift */; };
-		413DC024244BAFC96B1A3D3DADDD0C9E /* Marklight-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EBA4177D3ACA0687A22A67486B5DB02 /* Marklight-OSX-dummy.m */; };
+		3664F2379791BA3FB5233ED22A6933AE /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */; };
+		370C9C177882F3250C2AE059ED756C4E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */; };
 		42EF4612EDE4034EE0D12AF27E80034A /* Pods-Marklight-Marklight Sample-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 504AFCB6CDCED06DFA7CBCCE54EB4B10 /* Pods-Marklight-Marklight Sample-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		44BAD6158348D6FE49EEE205D8649192 /* Pods-Marklight-Marklight Sample macOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E6CB78FFFA83229A53A147A62F96F3 /* Pods-Marklight-Marklight Sample macOS-dummy.m */; };
-		5B94948F4CDE0E4B482D21B5F1A21604 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3990AEE660C8FA208A6F9055618BE800 /* Array+appending.swift */; };
-		7536D5F4614A0D5E298D944ACACD4957 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */; };
+		4781B9E1469B546300D45C7BA39578DB /* Marklight-OSX-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = B77DBBE59479C061249CF795CB03F80F /* Marklight-OSX-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		519848CA483F894A92BB87ADBA874549 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */; };
+		51CC562DEA3236D4FB6A41DC9C81D65F /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */; };
+		6E5797D9EEF3E318F65356927A54F236 /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */; };
+		7767F4899B96DF51A0A068810535C180 /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */; };
+		79BA9814D2CA62BD62A70B8C0FF43731 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */; };
 		8599BADDD54D8331FA293C0A63D5364D /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */; };
-		9A1CCE4126938E09003F44D51E73A864 /* Array+appending.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3990AEE660C8FA208A6F9055618BE800 /* Array+appending.swift */; };
-		9DC84DB852E0BE5A1828FC74DD6A5C62 /* Marklight-OSX-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 92AFEFCA86B4DBB8BA5A8481ABA8B345 /* Marklight-OSX-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B4329F7147DE48023ED9F4F2CECFE2CF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */; };
-		CF38F67B9D69CDD066376775684A6F6D /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A770FEC64CC51A0EC7FB727C96E4E4D /* MarklightTextStorage.swift */; };
+		8F9D7363963B17C61020C76B18516E03 /* NSString+paragraphRangeAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */; };
+		9CA5606C730E11C270D4EF63C450D33E /* MarklightTextProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */; };
+		ADB27804691505904B89614817DBA425 /* MarklightTextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */; };
+		B81E57417115ED06E2D22FC483007975 /* Marklight-iOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 11C7A870C264B19BC3BA5C46C79B024D /* Marklight-iOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C4255F2982780AEBC9FDADE730BDFC0E /* Marklight-OSX-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C0BA33EDBB3DDD87C304D8DA51428121 /* Marklight-OSX-dummy.m */; };
+		CDA6ED0FC38669F17F29450128284258 /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */; };
+		DCA7FDAB52F45CA422BC34BCE98C283A /* UniversalTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */; };
+		EA3143B795F02EEB17560B9647164174 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */; };
 		EB8BFD7AC77D589580982C6E57375A1F /* Pods-Marklight-Marklight Sample macOS-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D997AD92D29379A9564227402B1DB03 /* Pods-Marklight-Marklight Sample macOS-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		FDF13FE7CDBD428C21C6D63395C13CDB /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = E048FEFBEA05C67CEFB5D8F1278B20F1 /* Marklight.swift */; };
+		ECAC67C401D85631B0EA322C3BC3257A /* Marklight-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DBC34D49FDB9FFCDE3064ABFC924379F /* Marklight-iOS-dummy.m */; };
+		F83F9479DF7B128B6775740B14BDDEC0 /* Marklight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,72 +38,67 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7C12E0E15799EFAFC2DA84B6C882070B;
+			remoteGlobalIDString = D4A2D237D9ABC1BC6AED7D1ED13D58B6;
 			remoteInfo = "Marklight-OSX";
 		};
 		EDFF6DDEFC27C6A28120D9AF3896B194 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2EC1044C495F0E965171A6D14A99AB25;
+			remoteGlobalIDString = D78D99AFCE85B7A0335DB0F35509DA46;
 			remoteInfo = "Marklight-iOS";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		09226AE663C2BBB2FBAF315C196479F7 /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Marklight.framework; path = "Marklight-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0E7A482868F9BD057ACEA535FCA1E579 /* Marklight-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "Marklight-iOS.modulemap"; path = "../Marklight-iOS/Marklight-iOS.modulemap"; sourceTree = "<group>"; };
+		11C7A870C264B19BC3BA5C46C79B024D /* Marklight-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-umbrella.h"; path = "../Marklight-iOS/Marklight-iOS-umbrella.h"; sourceTree = "<group>"; };
+		176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NSString+paragraphRangeAt.swift"; sourceTree = "<group>"; };
 		1954BB0D4690843F084A66BA41B7CB09 /* Pods-Marklight-Marklight Sample macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample macOS.debug.xcconfig"; sourceTree = "<group>"; };
-		1CA4F175C2166EF467B224AC0D75B04C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Marklight-iOS/Info.plist"; sourceTree = "<group>"; };
-		2A770FEC64CC51A0EC7FB727C96E4E4D /* MarklightTextStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextStorage.swift; sourceTree = "<group>"; };
-		2CC2DA35FF32831CC81E34C88D10583B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		2EBA4177D3ACA0687A22A67486B5DB02 /* Marklight-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Marklight-OSX-dummy.m"; sourceTree = "<group>"; };
-		3990AEE660C8FA208A6F9055618BE800 /* Array+appending.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+appending.swift"; sourceTree = "<group>"; };
+		30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextProcessor.swift; sourceTree = "<group>"; };
+		3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Marklight.swift; sourceTree = "<group>"; };
 		4B5BAF31CDC2E5C8D6FB1C4E26D87313 /* Pods_Marklight_Marklight_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Marklight_Marklight_Sample.framework; path = "Pods-Marklight-Marklight Sample.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		504AFCB6CDCED06DFA7CBCCE54EB4B10 /* Pods-Marklight-Marklight Sample-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Marklight-Marklight Sample-umbrella.h"; sourceTree = "<group>"; };
 		56F6F4CECF6458464F20294A63B168F4 /* Pods-Marklight-Marklight Sample macOS-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample macOS-frameworks.sh"; sourceTree = "<group>"; };
 		5BEC194900724FA39134E150F2565D3B /* Pods-Marklight-Marklight Sample-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Marklight-Marklight Sample-acknowledgements.plist"; sourceTree = "<group>"; };
 		5DE6924255815EFAE93E0BE6DEC59070 /* Pods-Marklight-Marklight Sample macOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-Marklight-Marklight Sample macOS.modulemap"; sourceTree = "<group>"; };
-		5F78B93D1D21F6D0935B7E5E2FC65B87 /* Marklight-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-umbrella.h"; path = "../Marklight-iOS/Marklight-iOS-umbrella.h"; sourceTree = "<group>"; };
-		65671B917327F276C94EA18E9A4FB1EB /* Marklight-OSX.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Marklight-OSX.xcconfig"; sourceTree = "<group>"; };
-		694C2DCB28BDCC3DE5F0C4A993ACB18C /* Marklight-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-prefix.pch"; path = "../Marklight-iOS/Marklight-iOS-prefix.pch"; sourceTree = "<group>"; };
+		5E68ECA9B9BE2D491DA7DC56FDF362BF /* Marklight-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; name = "Marklight-iOS.modulemap"; path = "../Marklight-iOS/Marklight-iOS.modulemap"; sourceTree = "<group>"; };
+		60F2DF4C231091D14C81A4DE66A5E143 /* Marklight-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Marklight-iOS-prefix.pch"; path = "../Marklight-iOS/Marklight-iOS-prefix.pch"; sourceTree = "<group>"; };
 		71E6CB78FFFA83229A53A147A62F96F3 /* Pods-Marklight-Marklight Sample macOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Marklight-Marklight Sample macOS-dummy.m"; sourceTree = "<group>"; };
+		79A969CD7673F309545866367D462B9D /* Marklight-OSX.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Marklight-OSX.modulemap"; sourceTree = "<group>"; };
+		7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Marklight-iOS.xcconfig"; path = "../Marklight-iOS/Marklight-iOS.xcconfig"; sourceTree = "<group>"; };
 		843C32C9C475C8EC0FB7B7C033B8DEE9 /* Pods-Marklight-Marklight Sample.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-Marklight-Marklight Sample.modulemap"; sourceTree = "<group>"; };
-		89519AAD333DD1080C1BA48113AE4142 /* Marklight-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Marklight-iOS-dummy.m"; path = "../Marklight-iOS/Marklight-iOS-dummy.m"; sourceTree = "<group>"; };
-		92AFEFCA86B4DBB8BA5A8481ABA8B345 /* Marklight-OSX-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-umbrella.h"; sourceTree = "<group>"; };
+		9000EF24CB70E6F25A25DAF6B887E7FF /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = Info.plist; path = "../Marklight-iOS/Info.plist"; sourceTree = "<group>"; };
 		92BC6DE58210B38C700FD11D6A87D0F3 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UniversalTypes.swift; sourceTree = "<group>"; };
 		9A0C55E39FDA6434BFBEFA5297FF5F28 /* Pods-Marklight-Marklight Sample macOS-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Marklight-Marklight Sample macOS-acknowledgements.markdown"; sourceTree = "<group>"; };
 		9D997AD92D29379A9564227402B1DB03 /* Pods-Marklight-Marklight Sample macOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Marklight-Marklight Sample macOS-umbrella.h"; sourceTree = "<group>"; };
-		9EB1E9DB21C5BCC6FAF982A059B809BB /* Marklight-OSX-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-prefix.pch"; sourceTree = "<group>"; };
 		A183DAE50D3D1375CC1E5940AAD8669B /* Pods-Marklight-Marklight Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample.debug.xcconfig"; sourceTree = "<group>"; };
 		A9138CF4A09889A9CA257732DF184F40 /* Pods-Marklight-Marklight Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample.release.xcconfig"; sourceTree = "<group>"; };
-		A95EB358DF7472D9A016A02F2528F0A7 /* Marklight-OSX.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Marklight-OSX.modulemap"; sourceTree = "<group>"; };
+		B0B30CC1CD4D8F901668929DE510E5EF /* Marklight-OSX-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-prefix.pch"; sourceTree = "<group>"; };
 		B2AA5F181E888ACFDFF647DBBDF734C7 /* Pods-Marklight-Marklight Sample-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Marklight-Marklight Sample-dummy.m"; sourceTree = "<group>"; };
-		B5CC7650B9C65B50434B139702DFBC35 /* Marklight-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Marklight-iOS.xcconfig"; path = "../Marklight-iOS/Marklight-iOS.xcconfig"; sourceTree = "<group>"; };
+		B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarklightTextStorage.swift; sourceTree = "<group>"; };
+		B77DBBE59479C061249CF795CB03F80F /* Marklight-OSX-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Marklight-OSX-umbrella.h"; sourceTree = "<group>"; };
+		B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Marklight-OSX.xcconfig"; sourceTree = "<group>"; };
 		BAF7151CA41F63FD764D705A4A21486D /* Pods-Marklight-Marklight Sample macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Marklight-Marklight Sample macOS.release.xcconfig"; sourceTree = "<group>"; };
+		C0BA33EDBB3DDD87C304D8DA51428121 /* Marklight-OSX-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Marklight-OSX-dummy.m"; sourceTree = "<group>"; };
 		CDDAA23DDA8E082FC77E38FA01601C8F /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
+		CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Array+appending.swift"; sourceTree = "<group>"; };
 		D49625C52D5D30481B2951F7332F49B3 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D9699F78DFC2F89B90E2B41EFECFCF00 /* Pods-Marklight-Marklight Sample-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample-frameworks.sh"; sourceTree = "<group>"; };
 		DB8E2D632CADFEBE217900FD1D4F3ABF /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		E048FEFBEA05C67CEFB5D8F1278B20F1 /* Marklight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Marklight.swift; sourceTree = "<group>"; };
+		DBC34D49FDB9FFCDE3064ABFC924379F /* Marklight-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Marklight-iOS-dummy.m"; path = "../Marklight-iOS/Marklight-iOS-dummy.m"; sourceTree = "<group>"; };
 		E05DF1B938576A3A34C7C1D2D6460105 /* Pods-Marklight-Marklight Sample-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Marklight-Marklight Sample-acknowledgements.markdown"; sourceTree = "<group>"; };
 		E3992CF302A62CD93304B4800D70CB20 /* Pods-Marklight-Marklight Sample macOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample macOS-resources.sh"; sourceTree = "<group>"; };
 		E64FF4B4B61227C565A28D9F1A796579 /* Pods_Marklight_Marklight_Sample_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Marklight_Marklight_Sample_macOS.framework; path = "Pods-Marklight-Marklight Sample macOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8BD4078E9B4674831BB5E515FD95999 /* Pods-Marklight-Marklight Sample-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Marklight-Marklight Sample-resources.sh"; sourceTree = "<group>"; };
 		E9432A6655CE7E92A6099DAE20BF835D /* Marklight.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Marklight.framework; path = "Marklight-OSX.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC590753D13E25C74ACE4AE3BB2AD4E1 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FAC8140593AF379498930206868F9871 /* Pods-Marklight-Marklight Sample macOS-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Marklight-Marklight Sample macOS-acknowledgements.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		082AAF638ECD6CCE851A10D5EC04EB6E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7536D5F4614A0D5E298D944ACACD4957 /* Cocoa.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		838C3BCBCA9B8A3E1453B6A2CF5E9821 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -106,19 +107,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8672F8A873D7A27FFFCBC3EFF0A53D25 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B4329F7147DE48023ED9F4F2CECFE2CF /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8E153329DE6E7BC1BC46EA7FC2CE0E7B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				8599BADDD54D8331FA293C0A63D5364D /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9AAC9599A461936A2D144E75AA408C44 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				370C9C177882F3250C2AE059ED756C4E /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DEE2D98C1FD1DA05029E0A771F9E1252 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA3143B795F02EEB17560B9647164174 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -163,7 +172,7 @@
 		3CE0CAFB364A3E73297AABDAF874D71B /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				F1D5C1BC8706DC1C7E25C917F097CED1 /* Marklight */,
+				E70532A2910B368ACE48BAB31F64913D /* Marklight */,
 			);
 			name = "Development Pods";
 			sourceTree = "<group>";
@@ -177,26 +186,6 @@
 				E64FF4B4B61227C565A28D9F1A796579 /* Pods_Marklight_Marklight_Sample_macOS.framework */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		789751398F104D759E8E8FBCFDC1883A /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				2CC2DA35FF32831CC81E34C88D10583B /* Info.plist */,
-				1CA4F175C2166EF467B224AC0D75B04C /* Info.plist */,
-				0E7A482868F9BD057ACEA535FCA1E579 /* Marklight-iOS.modulemap */,
-				B5CC7650B9C65B50434B139702DFBC35 /* Marklight-iOS.xcconfig */,
-				89519AAD333DD1080C1BA48113AE4142 /* Marklight-iOS-dummy.m */,
-				694C2DCB28BDCC3DE5F0C4A993ACB18C /* Marklight-iOS-prefix.pch */,
-				5F78B93D1D21F6D0935B7E5E2FC65B87 /* Marklight-iOS-umbrella.h */,
-				A95EB358DF7472D9A016A02F2528F0A7 /* Marklight-OSX.modulemap */,
-				65671B917327F276C94EA18E9A4FB1EB /* Marklight-OSX.xcconfig */,
-				2EBA4177D3ACA0687A22A67486B5DB02 /* Marklight-OSX-dummy.m */,
-				9EB1E9DB21C5BCC6FAF982A059B809BB /* Marklight-OSX-prefix.pch */,
-				92AFEFCA86B4DBB8BA5A8481ABA8B345 /* Marklight-OSX-umbrella.h */,
-			);
-			name = "Support Files";
-			path = "Sample/Pods/Target Support Files/Marklight-OSX";
 			sourceTree = "<group>";
 		};
 		7DB346D0F39D3F0E887471402A8071AB = {
@@ -236,6 +225,20 @@
 			path = "Target Support Files/Pods-Marklight-Marklight Sample";
 			sourceTree = "<group>";
 		};
+		9A5C4845C142DE31B9D8582ACF6DA257 /* Marklight */ = {
+			isa = PBXGroup;
+			children = (
+				CE0832F22A0F472C6CC01434DAECF986 /* Array+appending.swift */,
+				3C9477C7E94D118D59C7C5634CAEF1F5 /* Marklight.swift */,
+				30C90ED56F3489679795459AE5B268E3 /* MarklightTextProcessor.swift */,
+				B6601CE67F00E1BE260EF894168CF36E /* MarklightTextStorage.swift */,
+				176D68CEFE4FF952C82EE8CDBC8D7E04 /* NSString+paragraphRangeAt.swift */,
+				953DF66382AEF9184EE579AE7110856B /* UniversalTypes.swift */,
+			);
+			name = Marklight;
+			path = Marklight;
+			sourceTree = "<group>";
+		};
 		D9264F83C4D02B328DC17E03FD692462 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -245,35 +248,44 @@
 			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		E82B5C20CD6074072C9A962DC8510B74 /* Marklight */ = {
+		E70532A2910B368ACE48BAB31F64913D /* Marklight */ = {
 			isa = PBXGroup;
 			children = (
-				3990AEE660C8FA208A6F9055618BE800 /* Array+appending.swift */,
-				E048FEFBEA05C67CEFB5D8F1278B20F1 /* Marklight.swift */,
-				2A770FEC64CC51A0EC7FB727C96E4E4D /* MarklightTextStorage.swift */,
-			);
-			name = Marklight;
-			path = Marklight;
-			sourceTree = "<group>";
-		};
-		F1D5C1BC8706DC1C7E25C917F097CED1 /* Marklight */ = {
-			isa = PBXGroup;
-			children = (
-				E82B5C20CD6074072C9A962DC8510B74 /* Marklight */,
-				789751398F104D759E8E8FBCFDC1883A /* Support Files */,
+				9A5C4845C142DE31B9D8582ACF6DA257 /* Marklight */,
+				FA36D0A18319FE94CA6A259977B6F78A /* Support Files */,
 			);
 			name = Marklight;
 			path = ../..;
 			sourceTree = "<group>";
 		};
+		FA36D0A18319FE94CA6A259977B6F78A /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				EC590753D13E25C74ACE4AE3BB2AD4E1 /* Info.plist */,
+				9000EF24CB70E6F25A25DAF6B887E7FF /* Info.plist */,
+				5E68ECA9B9BE2D491DA7DC56FDF362BF /* Marklight-iOS.modulemap */,
+				7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */,
+				DBC34D49FDB9FFCDE3064ABFC924379F /* Marklight-iOS-dummy.m */,
+				60F2DF4C231091D14C81A4DE66A5E143 /* Marklight-iOS-prefix.pch */,
+				11C7A870C264B19BC3BA5C46C79B024D /* Marklight-iOS-umbrella.h */,
+				79A969CD7673F309545866367D462B9D /* Marklight-OSX.modulemap */,
+				B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */,
+				C0BA33EDBB3DDD87C304D8DA51428121 /* Marklight-OSX-dummy.m */,
+				B0B30CC1CD4D8F901668929DE510E5EF /* Marklight-OSX-prefix.pch */,
+				B77DBBE59479C061249CF795CB03F80F /* Marklight-OSX-umbrella.h */,
+			);
+			name = "Support Files";
+			path = "Sample/Pods/Target Support Files/Marklight-OSX";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		8F129F482BEB631947D2E02D4F79BA9C /* Headers */ = {
+		502C507F87AF742C55CFB0764479B205 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9DC84DB852E0BE5A1828FC74DD6A5C62 /* Marklight-OSX-umbrella.h in Headers */,
+				4781B9E1469B546300D45C7BA39578DB /* Marklight-OSX-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -285,11 +297,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D24C34BB6D4AE58AD3734C2FE26C980D /* Headers */ = {
+		D43950DFCF3CF6F61F0BBEAADEAA0F91 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1EF1BCD06CE275FF3B3195FFC762E51A /* Marklight-iOS-umbrella.h in Headers */,
+				B81E57417115ED06E2D22FC483007975 /* Marklight-iOS-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -304,23 +316,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		2EC1044C495F0E965171A6D14A99AB25 /* Marklight-iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = E03BA7D33D4A54757E6BB4EA97729F9C /* Build configuration list for PBXNativeTarget "Marklight-iOS" */;
-			buildPhases = (
-				DCD27FB68AF86E3BFA76346EFDEFB117 /* Sources */,
-				8672F8A873D7A27FFFCBC3EFF0A53D25 /* Frameworks */,
-				D24C34BB6D4AE58AD3734C2FE26C980D /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Marklight-iOS";
-			productName = "Marklight-iOS";
-			productReference = 09226AE663C2BBB2FBAF315C196479F7 /* Marklight.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		697E675E9FEA55D981D23AC9EC78195F /* Pods-Marklight-Marklight Sample */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13BFD20C5B172C896675565104CE6EC4 /* Build configuration list for PBXNativeTarget "Pods-Marklight-Marklight Sample" */;
@@ -339,23 +334,6 @@
 			productReference = 4B5BAF31CDC2E5C8D6FB1C4E26D87313 /* Pods_Marklight_Marklight_Sample.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		7C12E0E15799EFAFC2DA84B6C882070B /* Marklight-OSX */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A25D13DC614FE2EE53C4AB937E39F683 /* Build configuration list for PBXNativeTarget "Marklight-OSX" */;
-			buildPhases = (
-				56B124BB7FFB3A3844BC9BA929F331EC /* Sources */,
-				082AAF638ECD6CCE851A10D5EC04EB6E /* Frameworks */,
-				8F129F482BEB631947D2E02D4F79BA9C /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Marklight-OSX";
-			productName = "Marklight-OSX";
-			productReference = E9432A6655CE7E92A6099DAE20BF835D /* Marklight.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		8EB7F7E7CF8D53F0D9C2D78CB060474D /* Pods-Marklight-Marklight Sample macOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7B557BD194741EC1237ECC77A6119938 /* Build configuration list for PBXNativeTarget "Pods-Marklight-Marklight Sample macOS" */;
@@ -372,6 +350,40 @@
 			name = "Pods-Marklight-Marklight Sample macOS";
 			productName = "Pods-Marklight-Marklight Sample macOS";
 			productReference = E64FF4B4B61227C565A28D9F1A796579 /* Pods_Marklight_Marklight_Sample_macOS.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D4A2D237D9ABC1BC6AED7D1ED13D58B6 /* Marklight-OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ABE5CD311792B8D7476EF9FFB5ED2CED /* Build configuration list for PBXNativeTarget "Marklight-OSX" */;
+			buildPhases = (
+				9A89A687ACCDDFB04B24CA0C0DAD669C /* Sources */,
+				9AAC9599A461936A2D144E75AA408C44 /* Frameworks */,
+				502C507F87AF742C55CFB0764479B205 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Marklight-OSX";
+			productName = "Marklight-OSX";
+			productReference = E9432A6655CE7E92A6099DAE20BF835D /* Marklight.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D78D99AFCE85B7A0335DB0F35509DA46 /* Marklight-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1B849E3796E0D2A8F36AD45B17FFBA8D /* Build configuration list for PBXNativeTarget "Marklight-iOS" */;
+			buildPhases = (
+				DA26E7CC9708A1F14EC14496D19E4B90 /* Sources */,
+				DEE2D98C1FD1DA05029E0A771F9E1252 /* Frameworks */,
+				D43950DFCF3CF6F61F0BBEAADEAA0F91 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Marklight-iOS";
+			productName = "Marklight-iOS";
+			productReference = 09226AE663C2BBB2FBAF315C196479F7 /* Marklight.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -395,8 +407,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				2EC1044C495F0E965171A6D14A99AB25 /* Marklight-iOS */,
-				7C12E0E15799EFAFC2DA84B6C882070B /* Marklight-OSX */,
+				D78D99AFCE85B7A0335DB0F35509DA46 /* Marklight-iOS */,
+				D4A2D237D9ABC1BC6AED7D1ED13D58B6 /* Marklight-OSX */,
 				697E675E9FEA55D981D23AC9EC78195F /* Pods-Marklight-Marklight Sample */,
 				8EB7F7E7CF8D53F0D9C2D78CB060474D /* Pods-Marklight-Marklight Sample macOS */,
 			);
@@ -412,17 +424,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		56B124BB7FFB3A3844BC9BA929F331EC /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9A1CCE4126938E09003F44D51E73A864 /* Array+appending.swift in Sources */,
-				413DC024244BAFC96B1A3D3DADDD0C9E /* Marklight-OSX-dummy.m in Sources */,
-				24BCF0333FD6E6C42D35AF9D8030DF3E /* Marklight.swift in Sources */,
-				CF38F67B9D69CDD066376775684A6F6D /* MarklightTextStorage.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		5D1014F74F5E7D5B33FDC262E85A6DD6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -431,14 +432,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DCD27FB68AF86E3BFA76346EFDEFB117 /* Sources */ = {
+		9A89A687ACCDDFB04B24CA0C0DAD669C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B94948F4CDE0E4B482D21B5F1A21604 /* Array+appending.swift in Sources */,
-				12814CDA839CD44B3CB35FE80F847638 /* Marklight-iOS-dummy.m in Sources */,
-				FDF13FE7CDBD428C21C6D63395C13CDB /* Marklight.swift in Sources */,
-				3E2144BB6CA49BE0729EA21AD9C054D2 /* MarklightTextStorage.swift in Sources */,
+				519848CA483F894A92BB87ADBA874549 /* Array+appending.swift in Sources */,
+				C4255F2982780AEBC9FDADE730BDFC0E /* Marklight-OSX-dummy.m in Sources */,
+				7767F4899B96DF51A0A068810535C180 /* Marklight.swift in Sources */,
+				6E5797D9EEF3E318F65356927A54F236 /* MarklightTextProcessor.swift in Sources */,
+				51CC562DEA3236D4FB6A41DC9C81D65F /* MarklightTextStorage.swift in Sources */,
+				8F9D7363963B17C61020C76B18516E03 /* NSString+paragraphRangeAt.swift in Sources */,
+				DCA7FDAB52F45CA422BC34BCE98C283A /* UniversalTypes.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA26E7CC9708A1F14EC14496D19E4B90 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				79BA9814D2CA62BD62A70B8C0FF43731 /* Array+appending.swift in Sources */,
+				ECAC67C401D85631B0EA322C3BC3257A /* Marklight-iOS-dummy.m in Sources */,
+				F83F9479DF7B128B6775740B14BDDEC0 /* Marklight.swift in Sources */,
+				9CA5606C730E11C270D4EF63C450D33E /* MarklightTextProcessor.swift in Sources */,
+				ADB27804691505904B89614817DBA425 /* MarklightTextStorage.swift in Sources */,
+				3664F2379791BA3FB5233ED22A6933AE /* NSString+paragraphRangeAt.swift in Sources */,
+				CDA6ED0FC38669F17F29450128284258 /* UniversalTypes.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -448,18 +466,89 @@
 		4EDD112EABC9E602DDC18E91B13AC62B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Marklight-iOS";
-			target = 2EC1044C495F0E965171A6D14A99AB25 /* Marklight-iOS */;
+			target = D78D99AFCE85B7A0335DB0F35509DA46 /* Marklight-iOS */;
 			targetProxy = EDFF6DDEFC27C6A28120D9AF3896B194 /* PBXContainerItemProxy */;
 		};
 		71B0F246F2104A714462AF51C4C585FC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Marklight-OSX";
-			target = 7C12E0E15799EFAFC2DA84B6C882070B /* Marklight-OSX */;
+			target = D4A2D237D9ABC1BC6AED7D1ED13D58B6 /* Marklight-OSX */;
 			targetProxy = 096959BF7B4A353DED187472DBE6949C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		05F96560E7899DDA9EE91F2C9ACB04AC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		08B884FB44472DC77B6FF0775B85F821 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B908E909C8FF0A3BBB0DDAED4F5C4AD9 /* Marklight-OSX.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		1EA6D4F64AEA6FC566C540F6A24C0816 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BAF7151CA41F63FD764D705A4A21486D /* Pods-Marklight-Marklight Sample macOS.release.xcconfig */;
@@ -539,6 +628,75 @@
 			};
 			name = Debug;
 		};
+		33B838B889FFAEED3E24326B3C9B27E0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		55018D6A7A7334B2F68208FFB2E786DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7EECC54C9F80636B0CBE77B7A21938CB /* Marklight-iOS.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = Marklight;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		5EDFEC883820B96EDB4FED824DDCDB9F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A183DAE50D3D1375CC1E5940AAD8669B /* Pods-Marklight-Marklight Sample.debug.xcconfig */;
@@ -578,42 +736,6 @@
 			};
 			name = Debug;
 		};
-		6176CA1D81EACABB0FE247B953507028 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 65671B917327F276C94EA18E9A4FB1EB /* Marklight-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Marklight;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		6A4CEC746BC55FB58DE9773FEA8BFD09 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A9138CF4A09889A9CA257732DF184F40 /* Pods-Marklight-Marklight Sample.release.xcconfig */;
@@ -642,75 +764,6 @@
 				PODS_ROOT = "$(SRCROOT)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = Pods_Marklight_Marklight_Sample;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		7132C6D071BA97889615FAA3329B112A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 65671B917327F276C94EA18E9A4FB1EB /* Marklight-OSX.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "-";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-OSX/Marklight-OSX-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-OSX/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MODULEMAP_FILE = "Target Support Files/Marklight-OSX/Marklight-OSX.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Marklight;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		97ADC37C7901F9E520392E4A0A025241 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B5CC7650B9C65B50434B139702DFBC35 /* Marklight-iOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = Marklight;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -815,41 +868,6 @@
 			};
 			name = Release;
 		};
-		D95BE142378795AC34FF97BE6F234531 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B5CC7650B9C65B50434B139702DFBC35 /* Marklight-iOS.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Marklight-iOS/Marklight-iOS-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Marklight-iOS/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Marklight-iOS/Marklight-iOS.modulemap";
-				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = Marklight;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -858,6 +876,15 @@
 			buildConfigurations = (
 				5EDFEC883820B96EDB4FED824DDCDB9F /* Debug */,
 				6A4CEC746BC55FB58DE9773FEA8BFD09 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1B849E3796E0D2A8F36AD45B17FFBA8D /* Build configuration list for PBXNativeTarget "Marklight-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55018D6A7A7334B2F68208FFB2E786DE /* Debug */,
+				33B838B889FFAEED3E24326B3C9B27E0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -880,20 +907,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A25D13DC614FE2EE53C4AB937E39F683 /* Build configuration list for PBXNativeTarget "Marklight-OSX" */ = {
+		ABE5CD311792B8D7476EF9FFB5ED2CED /* Build configuration list for PBXNativeTarget "Marklight-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6176CA1D81EACABB0FE247B953507028 /* Debug */,
-				7132C6D071BA97889615FAA3329B112A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		E03BA7D33D4A54757E6BB4EA97729F9C /* Build configuration list for PBXNativeTarget "Marklight-iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D95BE142378795AC34FF97BE6F234531 /* Debug */,
-				97ADC37C7901F9E520392E4A0A025241 /* Release */,
+				08B884FB44472DC77B6FF0775B85F821 /* Debug */,
+				05F96560E7899DDA9EE91F2C9ACB04AC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
While the `MarklightTextStorage` subclass works nice, if you have another external `NSTextStorage` subclass already, you cannot combine the two. This PR attempts to minimize the work you need to perform in your `NSTextStorage` subclass through delegation to a `MarklightTextProcessor` service instead of through inheritance.

(Works a bit towards #8 already, putting the style configuration in the `MarklightTextProcessor` and out of the text storage, where a style object can be extracted from later.)

I am not 100% happy with the name of the types I came up with, especially `MarklightStyleApplier` as a protocol that takes the minimum from `NSMutableAttributesString`, intending to make writing test doubles easier.