### PR TITLE
Add Explicit Initializer to MarklightTextProcessor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+## 1.3.x (2018-08-27)
+* Add initializer to `MarklightTextProcessor`.
+
 ## 1.3.0 (2017-08-11)
 * Marklight becomes pluggable [#8](https://github.com/macteo/Marklight/issues/8)
 * Support for bold-italic [#6](https://github.com/macteo/Marklight/issues/6)

--- a/Marklight/MarklightTextProcessor.swift
+++ b/Marklight/MarklightTextProcessor.swift
@@ -52,6 +52,9 @@ open class MarklightTextProcessor {
      */
     open var hideSyntax = false
 
+    // MARK: Initializers
+
+    public init() {}
 
     // MARK: Syntax highlighting
 


### PR DESCRIPTION
Currently, the implicitly synthesized init is inaccessible due to an 'internal' protection level.